### PR TITLE
Make tests locale independent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .classpath
 .settings
 .project
+.idea
+*.iml
 bin
 target
 src/main/java/com/joestelmach/natty/generated/*

--- a/src/test/java/com/joestelmach/natty/AbstractTest.java
+++ b/src/test/java/com/joestelmach/natty/AbstractTest.java
@@ -2,22 +2,31 @@ package com.joestelmach.natty;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.junit.Assert;
 import org.junit.Before;
 
 import com.joestelmach.natty.CalendarSource;
 import com.joestelmach.natty.Parser;
+import org.junit.BeforeClass;
 
 /**
  * 
  * @author Joe Stelmach
  */
 public abstract class AbstractTest {
-  private static final Calendar _calendar = Calendar.getInstance();
-  protected static final Parser _parser = new Parser();
-  
+  private static Calendar _calendar;
+  protected static Parser _parser;
+
+
+  public static void initCalendarAndParser() {
+    _calendar = Calendar.getInstance();
+    _parser = new Parser();
+  }
+
   /**
    * Resets the calendar source time before each test
    */
@@ -141,7 +150,7 @@ public abstract class AbstractTest {
    */
   protected void validateDateTime(Date date, int month, int day, int year, 
       int hours, int minutes, int seconds) {
-    
+
     _calendar.setTime(date);
     Assert.assertEquals(month -1, _calendar.get(Calendar.MONTH));
     Assert.assertEquals(day, _calendar.get(Calendar.DAY_OF_MONTH));

--- a/src/test/java/com/joestelmach/natty/DateTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTest.java
@@ -4,6 +4,7 @@ import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 import java.util.logging.ConsoleHandler;
@@ -23,7 +24,9 @@ import org.junit.Test;
 public class DateTest extends AbstractTest {
   @BeforeClass
   public static void oneTime() {
+    Locale.setDefault(Locale.US);
     TimeZone.setDefault(TimeZone.getTimeZone("US/Eastern"));
+    initCalendarAndParser();
   }
   
   @Test

--- a/src/test/java/com/joestelmach/natty/DateTimeTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTimeTest.java
@@ -3,6 +3,7 @@ package com.joestelmach.natty;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.junit.Assert;
@@ -17,7 +18,9 @@ import org.junit.Test;
 public class DateTimeTest extends AbstractTest {
   @BeforeClass
   public static void oneTime() {
+    Locale.setDefault(Locale.US);
     TimeZone.setDefault(TimeZone.getTimeZone("US/Eastern"));
+    initCalendarAndParser();
   }
   
   @Test

--- a/src/test/java/com/joestelmach/natty/HolidayTest.java
+++ b/src/test/java/com/joestelmach/natty/HolidayTest.java
@@ -2,6 +2,7 @@ package com.joestelmach.natty;
 
 import java.text.DateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.junit.BeforeClass;
@@ -12,7 +13,9 @@ public class HolidayTest extends AbstractTest {
    
   @BeforeClass
   public static void oneTime() {
+    Locale.setDefault(Locale.US);
     TimeZone.setDefault(TimeZone.getTimeZone("US/Eastern"));
+    initCalendarAndParser();
   }
   
   @Test

--- a/src/test/java/com/joestelmach/natty/TimeTest.java
+++ b/src/test/java/com/joestelmach/natty/TimeTest.java
@@ -3,6 +3,7 @@ package com.joestelmach.natty;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.junit.Assert;
@@ -17,7 +18,9 @@ import org.junit.Test;
 public class TimeTest extends AbstractTest {
   @BeforeClass
   public static void oneTime() {
+    Locale.setDefault(Locale.US);
     TimeZone.setDefault(TimeZone.getTimeZone("US/Eastern"));
+    initCalendarAndParser();
   }
   
   /**


### PR DESCRIPTION
Tests are failing now on non-US computer because of different date format: 20/12/2010 (non-US) vs 12/20/2010 (US). 
Creation of current calendar must be done after setting default Timezone. Otherwise it gets invalid timezone (not 'US/Eastern').
