### PR TITLE
Make parser thread safe.

### DIFF
--- a/src/main/java/com/joestelmach/natty/CalendarSource.java
+++ b/src/main/java/com/joestelmach/natty/CalendarSource.java
@@ -6,22 +6,22 @@ import java.util.GregorianCalendar;
 /**
  * Responsible for generating new Calendars that represent
  * the current point in time.  This is neccessary so we can
- * manipulate what the software thinks is the 'current' 
+ * manipulate what the software thinks is the 'current'
  * time, which may be different than the system time
- * 
+ *
  * @author Joe Stelmach
  */
-class CalendarSource {
-  private static Date _baseDate;
-  
+public class CalendarSource {
+  private static ThreadLocal<Date> _baseDate = new ThreadLocal<Date>();
+
   public static void setBaseDate(Date baseDate) {
-    _baseDate = baseDate;
+    _baseDate.set(baseDate);
   }
 
   public static GregorianCalendar getCurrentCalendar() {
     GregorianCalendar calendar = new GregorianCalendar();
-    if(_baseDate != null) {
-      calendar.setTime(_baseDate);
+    if(_baseDate.get() != null) {
+      calendar.setTime(_baseDate.get());
     }
     return calendar;
   }

--- a/src/test/java/com/joestelmach/natty/ThreadSafetyTest.java
+++ b/src/test/java/com/joestelmach/natty/ThreadSafetyTest.java
@@ -1,0 +1,74 @@
+package com.joestelmach.natty;
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.TimeZone;
+
+import org.junit.Assert;
+
+import org.junit.Test;
+import org.junit.BeforeClass;
+
+public class ThreadSafetyTest extends AbstractTest {
+
+  private final static int NUM_OF_THREADS = 10;
+  private final static int JOIN_TIMEOUT = 2000; // 2 seconds
+  private static DateFormat dateFormat;
+
+  private AtomicInteger numOfCorrectResults = new AtomicInteger();
+
+  @BeforeClass
+  public static void oneTime() {
+    Locale.setDefault(Locale.US);
+    TimeZone.setDefault(TimeZone.getTimeZone("US/Eastern"));
+    dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, Locale.US);
+    initCalendarAndParser();
+  }
+
+  @Test
+  public void testManyThreads() throws Exception {
+    Thread[] threads = new Thread[NUM_OF_THREADS];
+    for (int i = 0; i < NUM_OF_THREADS; i++) {
+      threads[i] = new Thread(new Tester(i));
+    }
+    for (Thread thread : threads) {
+      thread.start();
+    }
+    for (Thread thread : threads) {
+      thread.join(JOIN_TIMEOUT);
+    }
+    Assert.assertEquals(NUM_OF_THREADS, numOfCorrectResults.get());
+  }
+
+  private class Tester implements Runnable {
+
+    private Date baseDate;
+    private int baseMinute;
+
+    public Tester(int baseMinute) throws Exception {
+      String date = String.format("3/3/2011 1:%02d am", baseMinute);
+      this.baseDate = dateFormat.parse(date);
+      this.baseMinute = baseMinute;
+    }
+
+    public void run() {
+      CalendarSource.setBaseDate(baseDate);
+      try {
+        // Immitate some long running task.
+        Thread.sleep(100);
+      } catch (Exception e) { }
+      String newDate = "4/4/2012";
+      Date parsed = _parser.parse(newDate).get(0).getDates().get(0);
+      validateThread(parsed, baseMinute);
+      numOfCorrectResults.incrementAndGet();
+    }
+  }
+
+  // We need this method, because validateDate and validateTime are not thread safe.
+  private synchronized void validateThread(Date date, int baseMinute) {
+    validateDate(date, 4, 4, 2012);
+    validateTime(date, 1, baseMinute, 0);
+  }
+}


### PR DESCRIPTION
`Parser` uses only 1 external variable during parsing: `_baseDate` from `CalendarSource`, all other stuff `Parser` creates locally in methods. I added thread safety my making `_baseDate` variable in `CalendarSource` thread local. Also I made `CalendarSource` public, so user can set basedate manually.
