### PR TITLE
Please enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+##
+# Which language are we using.
+language: java
+
+##
+# Not doing sudo things so use a fast-starting build container.
+sudo: false
+
+##
+# Test against the popular implementations of Java.
+jdk:
+  - oraclejdk7
+  - openjdk7

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
+# Natty
+
+![Build status](https://api.travis-ci.org/joestelmach/natty.svg?branch=master)
+
 Natty is a natural language date parser written in Java.  Given a date
 expression, natty will apply standard language recognition and translation
 techniques to produce a list of corresponding dates with optional parse and
 syntax information.
 
-Complete documentation can be found here:
-http://natty.joestelmach.com
+Complete documentation can be found here: <http://natty.joestelmach.com>


### PR DESCRIPTION
Those of use using Natty commercially would feel safer if you enabled some form of CI for it, to catch PRs which might break master before it's too late.

Travis CI is trivial to get started with, is free for open source, and just uses your GH credentials (no separate username/password needed) so I've provided you a Travis config which works. See it in action on my fork at <https://travis-ci.org/themasterchef/natty>

Note: the pretty build status image will say 'unknown' until such a time that you enable the upstream build on Travis, but should change to 'passing' after that.