### PR TITLE
fixing 'days ago' for numbers with one or two trailing zeroes

### DIFF
--- a/src/main/antlr3/com/joestelmach/natty/generated/imports/NumericRules.g
+++ b/src/main/antlr3/com/joestelmach/natty/generated/imports/NumericRules.g
@@ -65,7 +65,8 @@ spelled_or_int_01_to_31_optional_prefix
 spelled_or_int_optional_prefix
   : spelled_one_to_thirty_one // TODO expand this spelled range to at least ninety-nine
   | ((int_01_to_31_optional_prefix | int_32_to_59 | int_60_to_99)
-     (int_01_to_31_optional_prefix | int_32_to_59 | int_60_to_99)?
+     ( INT_0 | INT_00 | int_01_to_31_optional_prefix | int_32_to_59 | int_60_to_99)?
+     
        -> INT[$spelled_or_int_optional_prefix.text])
   ;
   

--- a/src/test/java/com/joestelmach/natty/DateTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTest.java
@@ -85,6 +85,8 @@ public class DateTest extends AbstractTest {
     validateDate("seven years ago", 2, 28, 2004);
     validateDate("60 years ago", 2, 28, 1951);
     validateDate("32 days ago", 1, 27, 2011);
+    validateDate("320 days ago", 4, 14, 2010);
+    validateDate("1200 days ago", 11, 16, 2007);
     validateDate("next monday", 3, 7, 2011);
     validateDate("next mon", 3, 7, 2011);
     validateDate("4 mondays from now", 3, 28, 2011);

--- a/src/test/java/com/joestelmach/natty/grammar/DateGrammarTest.java
+++ b/src/test/java/com/joestelmach/natty/grammar/DateGrammarTest.java
@@ -221,6 +221,8 @@ public class DateGrammarTest extends AbstractGrammarTest {
     assertAST("seven years ago", "(RELATIVE_DATE (SEEK < by_day 7 year))");
     assertAST("60 years ago", "(RELATIVE_DATE (SEEK < by_day 60 year))");
     assertAST("32 days ago", "(RELATIVE_DATE (SEEK < by_day 32 day))");
+    assertAST("150 days ago", "(RELATIVE_DATE (SEEK < by_day 150 day))");
+    assertAST("1500 days ago", "(RELATIVE_DATE (SEEK < by_day 1500 day))");
     assertAST("next monday", "(RELATIVE_DATE (SEEK > by_week 1 (DAY_OF_WEEK 2)))");
     assertAST("next mon", "(RELATIVE_DATE (SEEK > by_week 1 (DAY_OF_WEEK 2)))");
     assertAST("4 mondays from now", "(RELATIVE_DATE (SEEK > by_day 4 (DAY_OF_WEEK 2)))");


### PR DESCRIPTION
fixes #99 