### PR TITLE
Make log4j test only dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.10</version>
+      <scope>test</scope>
     </dependency>
     
     <dependency>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=info, stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.err
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%-5p %d{yyyy-MM-dd HH:mm:ss} %c{1}:%L - %m %n


### PR DESCRIPTION
Allow any slf4j backend to be used instead of always bringing in log4j.