### PR TITLE
Relative date fix

### DIFF
--- a/src/main/java/com/joestelmach/natty/WalkerState.java
+++ b/src/main/java/com/joestelmach/natty/WalkerState.java
@@ -177,12 +177,14 @@ public class WalkerState {
     if(seekAmountInt > 0) {
       int currentMonth = _calendar.get(Calendar.MONTH) + 1;
       int sign = direction.equals(DIR_RIGHT) ? 1 : -1;
-      int numYearsToShift = seekAmountInt + (currentMonth < monthInt ? 1: 0) * ((sign > 0) ? -1 : 0);
+      int numYearsToShift = seekAmountInt +
+              (currentMonth == monthInt ? 0 : (currentMonth < monthInt ? sign > 0 ? -1 : 0 : sign > 0 ? 0 : -1));
+
       _calendar.add(Calendar.YEAR, (numYearsToShift * sign));
     }
     
     // now set the month
-    _calendar.set(Calendar.MONTH, monthInt -1);
+    _calendar.set(Calendar.MONTH, monthInt - 1);
   }
   
   /**

--- a/src/main/java/com/joestelmach/natty/WalkerState.java
+++ b/src/main/java/com/joestelmach/natty/WalkerState.java
@@ -177,8 +177,7 @@ public class WalkerState {
     if(seekAmountInt > 0) {
       int currentMonth = _calendar.get(Calendar.MONTH) + 1;
       int sign = direction.equals(DIR_RIGHT) ? 1 : -1;
-      int numYearsToShift = seekAmountInt + 
-        (currentMonth <= monthInt ? sign > 0 ? -1 : 0 : sign > 0 ? 0 : -1);
+      int numYearsToShift = seekAmountInt + (currentMonth < monthInt ? 1: 0) * ((sign > 0) ? -1 : 0);
       _calendar.add(Calendar.YEAR, (numYearsToShift * sign));
     }
     

--- a/src/test/java/com/joestelmach/natty/DateTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTest.java
@@ -116,6 +116,9 @@ public class DateTest extends AbstractTest {
     validateDate("september", 9, 1, 2011);
     validateDate("last september", 9, 1, 2010);
     validateDate("next september", 9, 1, 2011);
+    validateDate("next february", 2, 1, 2012);
+    validateDate("last february", 2, 1, 2010);
+    validateDate("february ", 2, 1, 2011);
     validateDate("in a year", 2, 28, 2012);
     validateDate("in a week", 3, 7, 2011);
     validateDate("the saturday after next", 3, 19, 2011);

--- a/src/test/java/com/joestelmach/natty/DateTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTest.java
@@ -116,6 +116,9 @@ public class DateTest extends AbstractTest {
     validateDate("september", 9, 1, 2011);
     validateDate("last september", 9, 1, 2010);
     validateDate("next september", 9, 1, 2011);
+    validateDate("january", 1, 1, 2011);
+    validateDate("last january", 1, 1, 2011);
+    validateDate("next january", 1, 1, 2012);
     validateDate("next february", 2, 1, 2012);
     validateDate("last february", 2, 1, 2010);
     validateDate("february ", 2, 1, 2011);


### PR DESCRIPTION
This pull request refactors the logic in the `seekToMonth` method to handle the use case of when you want to specify the next time a month exists but you are currently within that month.

This refactors the `numYearsToShift` to never negatively shift if it's the same month.

This passes all existing tests  Plus a few more I've added.

Resolves https://github.com/joestelmach/natty/issues/131