### PR TITLE
Adds support for relative dates

### DIFF
--- a/src/main/antlr3/com/joestelmach/natty/generated/DateWalker.g
+++ b/src/main/antlr3/com/joestelmach/natty/generated/DateWalker.g
@@ -9,7 +9,7 @@ options {
 
 @members {
   private com.joestelmach.natty.WalkerState _walkerState;
-  private java.util.Date baseDate;
+  private java.util.Date referenceDate;
 
   @Override
   protected Object recoverFromMismatchedToken(IntStream input, int ttype, BitSet follow)
@@ -23,13 +23,13 @@ options {
     throw e;
   }
 
-  public void setBaseDate(java.util.Date baseDate) {
-    this.baseDate = baseDate;
+  public void setBaseDate(java.util.Date referenceDate) {
+    this.referenceDate = referenceDate;
   }
 
   public com.joestelmach.natty.WalkerState getState() {
     if(_walkerState==null) {
-      _walkerState = new com.joestelmach.natty.WalkerState(baseDate);
+      _walkerState = new com.joestelmach.natty.WalkerState(referenceDate);
     }
     return _walkerState;
   }

--- a/src/main/antlr3/com/joestelmach/natty/generated/DateWalker.g
+++ b/src/main/antlr3/com/joestelmach/natty/generated/DateWalker.g
@@ -23,7 +23,7 @@ options {
     throw e;
   }
 
-  public void setBaseDate(java.util.Date referenceDate) {
+  public void setReferenceDate(java.util.Date referenceDate) {
     this.referenceDate = referenceDate;
   }
 

--- a/src/main/antlr3/com/joestelmach/natty/generated/DateWalker.g
+++ b/src/main/antlr3/com/joestelmach/natty/generated/DateWalker.g
@@ -8,7 +8,8 @@ options {
 @header { package com.joestelmach.natty.generated; }
 
 @members {
-  private com.joestelmach.natty.WalkerState _walkerState = new com.joestelmach.natty.WalkerState();
+  private com.joestelmach.natty.WalkerState _walkerState;
+  private java.util.Date baseDate;
 
   @Override
   protected Object recoverFromMismatchedToken(IntStream input, int ttype, BitSet follow)
@@ -22,7 +23,14 @@ options {
     throw e;
   }
 
+  public void setBaseDate(java.util.Date baseDate) {
+    this.baseDate = baseDate;
+  }
+
   public com.joestelmach.natty.WalkerState getState() {
+    if(_walkerState==null) {
+      _walkerState = new com.joestelmach.natty.WalkerState(baseDate);
+    }
     return _walkerState;
   }
 }

--- a/src/main/java/com/joestelmach/natty/CalendarSource.java
+++ b/src/main/java/com/joestelmach/natty/CalendarSource.java
@@ -12,17 +12,19 @@ import java.util.GregorianCalendar;
  * @author Joe Stelmach
  */
 public class CalendarSource {
-  private static ThreadLocal<Date> _baseDate = new ThreadLocal<Date>();
+  private Date _baseDate;
 
-  public static void setBaseDate(Date baseDate) {
-    _baseDate.set(baseDate);
+  public CalendarSource() {
+    this._baseDate = new Date();
   }
 
-  public static GregorianCalendar getCurrentCalendar() {
+  public CalendarSource(Date baseDate) {
+    this._baseDate = baseDate;
+  }
+
+  public GregorianCalendar getCurrentCalendar() {
     GregorianCalendar calendar = new GregorianCalendar();
-    if(_baseDate.get() != null) {
-      calendar.setTime(_baseDate.get());
-    }
+    calendar.setTime(_baseDate);
     return calendar;
   }
 }

--- a/src/main/java/com/joestelmach/natty/CalendarSource.java
+++ b/src/main/java/com/joestelmach/natty/CalendarSource.java
@@ -12,19 +12,19 @@ import java.util.GregorianCalendar;
  * @author Joe Stelmach
  */
 public class CalendarSource {
-  private Date _baseDate;
+  private Date referenceDate;
 
   public CalendarSource() {
-    this._baseDate = new Date();
+    this.referenceDate = new Date();
   }
 
-  public CalendarSource(Date baseDate) {
-    this._baseDate = baseDate;
+  public CalendarSource(Date referenceDate) {
+    this.referenceDate = referenceDate;
   }
 
   public GregorianCalendar getCurrentCalendar() {
     GregorianCalendar calendar = new GregorianCalendar();
-    calendar.setTime(_baseDate);
+    calendar.setTime(referenceDate);
     return calendar;
   }
 }

--- a/src/main/java/com/joestelmach/natty/IcsSearcher.java
+++ b/src/main/java/com/joestelmach/natty/IcsSearcher.java
@@ -24,8 +24,8 @@ public class IcsSearcher {
   private TimeZone _timeZone;
   private CalendarSource calendarSource;
 
-  public IcsSearcher(String calendarFileName, TimeZone timeZone, Date baseDate) {
-    calendarSource = new CalendarSource(baseDate);
+  public IcsSearcher(String calendarFileName, TimeZone timeZone, Date referenceDate) {
+    calendarSource = new CalendarSource(referenceDate);
     _calendarFileName = calendarFileName;
     _timeZone = timeZone;
   }

--- a/src/main/java/com/joestelmach/natty/IcsSearcher.java
+++ b/src/main/java/com/joestelmach/natty/IcsSearcher.java
@@ -22,10 +22,16 @@ public class IcsSearcher {
   private net.fortuna.ical4j.model.Calendar _holidayCalendar;
   private String _calendarFileName;
   private TimeZone _timeZone;
-  
-  public IcsSearcher(String calendarFileName, TimeZone timeZone) {
+  private CalendarSource calendarSource;
+
+  public IcsSearcher(String calendarFileName, TimeZone timeZone, Date baseDate) {
+    calendarSource = new CalendarSource(baseDate);
     _calendarFileName = calendarFileName;
     _timeZone = timeZone;
+  }
+
+  public IcsSearcher(String calendarFileName, TimeZone timeZone) {
+    this(calendarFileName, timeZone, new Date());
   }
 
   public Map<Integer, Date> findDates(int startYear, int endYear, String eventSummary) {
@@ -66,12 +72,12 @@ public class IcsSearcher {
           DateTime date = ((Period) p).getStart();
           
           // this date is at the date of the holiday at 12 AM UTC
-          Calendar utcCal = CalendarSource.getCurrentCalendar();
+          Calendar utcCal = calendarSource.getCurrentCalendar();
           utcCal.setTimeZone(TimeZone.getTimeZone(GMT));
           utcCal.setTime(date);
           
           // use the year, month and day components of our UTC date to form a new local date
-          Calendar localCal = CalendarSource.getCurrentCalendar();
+          Calendar localCal = calendarSource.getCurrentCalendar();
           localCal.setTimeZone(_timeZone);
           localCal.set(Calendar.YEAR, utcCal.get(Calendar.YEAR));
           localCal.set(Calendar.MONTH, utcCal.get(Calendar.MONTH));

--- a/src/main/java/com/joestelmach/natty/Parser.java
+++ b/src/main/java/com/joestelmach/natty/Parser.java
@@ -215,7 +215,7 @@ public class Parser {
         nodes = new CommonTreeNodeStream(tree);
         nodes.setTokenStream(stream);
         DateWalker walker = new DateWalker(nodes);
-        walker.setBaseDate(referenceDate);
+        walker.setReferenceDate(referenceDate);
         walker.getState().setDefaultTimeZone(_defaultTimeZone);
         walker.parse();
         _logger.info("AST: " + tree.toStringTree());

--- a/src/main/java/com/joestelmach/natty/Parser.java
+++ b/src/main/java/com/joestelmach/natty/Parser.java
@@ -64,6 +64,19 @@ public class Parser {
    * @return
    */
   public List<DateGroup> parse(String value) {
+    return parse(value, new Date());
+  }
+
+  /**
+   * Parses the given input value for one or more groups of
+   * date alternatives with relative dates resolved according
+   * to baseDate
+   *
+   * @param value
+   * @param baseDate
+   * @return
+   */
+  public List<DateGroup> parse(String value, Date baseDate) {
 
     // lex the input value to obtain our global token stream
     ANTLRInputStream input = null;
@@ -84,7 +97,7 @@ public class Parser {
     for(TokenStream stream:streams) {
       lastStream = stream;
       List<Token> tokens = ((NattyTokenSource) stream.getTokenSource()).getTokens();
-      DateGroup group = singleParse(stream, value);
+      DateGroup group = singleParse(stream, value, baseDate);
       while((group == null || group.getDates().size() == 0) && tokens.size() > 0) {
         if(group == null || group.getDates().size() == 0) {
           
@@ -96,7 +109,7 @@ public class Parser {
           while((group == null || group.getDates().isEmpty()) && !endRemovedTokens.isEmpty()) {
             endRemovedTokens = endRemovedTokens.subList(0, endRemovedTokens.size() - 1);
             TokenStream newStream = new CommonTokenStream(new NattyTokenSource(endRemovedTokens));
-            group = singleParse(newStream, value);
+            group = singleParse(newStream, value, baseDate);
             lastStream = newStream;
           }
 
@@ -115,7 +128,7 @@ public class Parser {
               }
             }
             TokenStream newStream = new CommonTokenStream(new NattyTokenSource(tokens));
-            group = singleParse(newStream, value);
+            group = singleParse(newStream, value, baseDate);
             lastStream = newStream;
           }
         }
@@ -170,7 +183,7 @@ public class Parser {
    * @param stream
    * @return
    */
-  private DateGroup singleParse(TokenStream stream, String fullText) {
+  private DateGroup singleParse(TokenStream stream, String fullText, Date baseDate) {
 	DateGroup group = null;
 	List<Token> tokens = ((NattyTokenSource) stream.getTokenSource()).getTokens();
 	if(tokens.isEmpty()) return group;
@@ -202,6 +215,7 @@ public class Parser {
         nodes = new CommonTreeNodeStream(tree);
         nodes.setTokenStream(stream);
         DateWalker walker = new DateWalker(nodes);
+        walker.setBaseDate(baseDate);
         walker.getState().setDefaultTimeZone(_defaultTimeZone);
         walker.parse();
         _logger.info("AST: " + tree.toStringTree());

--- a/src/main/java/com/joestelmach/natty/Parser.java
+++ b/src/main/java/com/joestelmach/natty/Parser.java
@@ -70,13 +70,13 @@ public class Parser {
   /**
    * Parses the given input value for one or more groups of
    * date alternatives with relative dates resolved according
-   * to baseDate
+   * to referenceDate
    *
    * @param value
-   * @param baseDate
+   * @param referenceDate
    * @return
    */
-  public List<DateGroup> parse(String value, Date baseDate) {
+  public List<DateGroup> parse(String value, Date referenceDate) {
 
     // lex the input value to obtain our global token stream
     ANTLRInputStream input = null;
@@ -97,7 +97,7 @@ public class Parser {
     for(TokenStream stream:streams) {
       lastStream = stream;
       List<Token> tokens = ((NattyTokenSource) stream.getTokenSource()).getTokens();
-      DateGroup group = singleParse(stream, value, baseDate);
+      DateGroup group = singleParse(stream, value, referenceDate);
       while((group == null || group.getDates().size() == 0) && tokens.size() > 0) {
         if(group == null || group.getDates().size() == 0) {
           
@@ -109,7 +109,7 @@ public class Parser {
           while((group == null || group.getDates().isEmpty()) && !endRemovedTokens.isEmpty()) {
             endRemovedTokens = endRemovedTokens.subList(0, endRemovedTokens.size() - 1);
             TokenStream newStream = new CommonTokenStream(new NattyTokenSource(endRemovedTokens));
-            group = singleParse(newStream, value, baseDate);
+            group = singleParse(newStream, value, referenceDate);
             lastStream = newStream;
           }
 
@@ -128,7 +128,7 @@ public class Parser {
               }
             }
             TokenStream newStream = new CommonTokenStream(new NattyTokenSource(tokens));
-            group = singleParse(newStream, value, baseDate);
+            group = singleParse(newStream, value, referenceDate);
             lastStream = newStream;
           }
         }
@@ -183,7 +183,7 @@ public class Parser {
    * @param stream
    * @return
    */
-  private DateGroup singleParse(TokenStream stream, String fullText, Date baseDate) {
+  private DateGroup singleParse(TokenStream stream, String fullText, Date referenceDate) {
 	DateGroup group = null;
 	List<Token> tokens = ((NattyTokenSource) stream.getTokenSource()).getTokens();
 	if(tokens.isEmpty()) return group;
@@ -215,7 +215,7 @@ public class Parser {
         nodes = new CommonTreeNodeStream(tree);
         nodes.setTokenStream(stream);
         DateWalker walker = new DateWalker(nodes);
-        walker.setBaseDate(baseDate);
+        walker.setBaseDate(referenceDate);
         walker.getState().setDefaultTimeZone(_defaultTimeZone);
         walker.parse();
         _logger.info("AST: " + tree.toStringTree());

--- a/src/main/java/com/joestelmach/natty/WalkerState.java
+++ b/src/main/java/com/joestelmach/natty/WalkerState.java
@@ -48,8 +48,8 @@ public class WalkerState {
     this(new Date());
   }
 
-  public WalkerState(Date baseDate) {
-    calendarSource = new CalendarSource(baseDate);
+  public WalkerState(Date referenceDate) {
+    calendarSource = new CalendarSource(referenceDate);
     resetCalendar();
     _dateGroup = new DateGroup();
   }

--- a/src/main/java/com/joestelmach/natty/WalkerState.java
+++ b/src/main/java/com/joestelmach/natty/WalkerState.java
@@ -28,6 +28,7 @@ public class WalkerState {
   private static final String HOLIDAY_ICS_FILE = "/holidays.ics";
   private static final String SEASON_ICS_FILE = "/seasons.ics";
 
+  private CalendarSource calendarSource;
   private GregorianCalendar _calendar;
   private TimeZone _defaultTimeZone;
   private int _currentYear;
@@ -44,6 +45,11 @@ public class WalkerState {
    * the next hour from the current time
    */
   public WalkerState() {
+    this(new Date());
+  }
+
+  public WalkerState(Date baseDate) {
+    calendarSource = new CalendarSource(baseDate);
     resetCalendar();
     _dateGroup = new DateGroup();
   }
@@ -675,6 +681,6 @@ public class WalkerState {
    * @return the current calendar
    */
   protected GregorianCalendar getCalendar() {
-    return CalendarSource.getCurrentCalendar();
+    return calendarSource.getCurrentCalendar();
   }
 }

--- a/src/test/java/com/joestelmach/natty/AbstractTest.java
+++ b/src/test/java/com/joestelmach/natty/AbstractTest.java
@@ -14,6 +14,7 @@ import java.util.List;
  */
 public abstract class AbstractTest {
   private static Calendar _calendar;
+  protected static CalendarSource calendarSource;
   protected static Parser _parser;
 
 
@@ -27,7 +28,7 @@ public abstract class AbstractTest {
    */
   @Before
   public void before() {
-    CalendarSource.setBaseDate(null);
+    calendarSource = new CalendarSource();
   }
   
   /**
@@ -36,8 +37,8 @@ public abstract class AbstractTest {
    * @param value
    * @return
    */
-  protected List<Date> parseCollection(String value) {
-    List<DateGroup> dateGroup = _parser.parse(value);
+  protected List<Date> parseCollection(String value, Date baseDate) {
+    List<DateGroup> dateGroup = _parser.parse(value, baseDate);
     return dateGroup.isEmpty() ? new ArrayList<Date>() : dateGroup.get(0).getDates();
   }
   
@@ -47,8 +48,8 @@ public abstract class AbstractTest {
    * @param value
    * @return
    */
-  protected Date parseSingleDate(String value) {
-    List<Date> dates = parseCollection(value);
+  protected Date parseSingleDate(String value, Date baseDate) {
+    List<Date> dates = parseCollection(value, baseDate);
     Assert.assertEquals(1, dates.size());
     return dates.get(0);
   }
@@ -62,8 +63,8 @@ public abstract class AbstractTest {
    * @param day
    * @param year
    */
-  protected void validateDate(String value, int month, int day, int year) {
-    Date date = parseSingleDate(value);
+  protected void validateDate(Date baseDate, String value, int month, int day, int year) {
+    Date date = parseSingleDate(value, baseDate);
     validateDate(date, month, day, year);
   }
   
@@ -92,8 +93,8 @@ public abstract class AbstractTest {
    * @param minutes
    * @param seconds
    */
-  protected void validateTime(String value, int hours, int minutes, int seconds) {
-    Date date = parseSingleDate(value);
+  protected void validateTime(Date baseDate, String value, int hours, int minutes, int seconds) {
+    Date date = parseSingleDate(value, baseDate);
     validateTime(date, hours, minutes, seconds);
   }
   
@@ -126,10 +127,10 @@ public abstract class AbstractTest {
    * @param minutes
    * @param seconds
    */
-  protected void validateDateTime(String value, int month, int day, int year, 
+  protected void validateDateTime(Date baseDate, String value, int month, int day, int year,
       int hours, int minutes, int seconds) {
     
-    Date date = parseSingleDate(value);
+    Date date = parseSingleDate(value, baseDate);
     validateDateTime(date, month, day, year, hours, minutes, seconds);
   }
   

--- a/src/test/java/com/joestelmach/natty/AbstractTest.java
+++ b/src/test/java/com/joestelmach/natty/AbstractTest.java
@@ -37,7 +37,7 @@ public abstract class AbstractTest {
    * @param value
    * @return
    */
-  protected List<Date> parseCollection(String value, Date baseDate) {
+  protected List<Date> parseCollection(Date baseDate, String value) {
     List<DateGroup> dateGroup = _parser.parse(value, baseDate);
     return dateGroup.isEmpty() ? new ArrayList<Date>() : dateGroup.get(0).getDates();
   }
@@ -49,7 +49,7 @@ public abstract class AbstractTest {
    * @return
    */
   protected Date parseSingleDate(String value, Date baseDate) {
-    List<Date> dates = parseCollection(value, baseDate);
+    List<Date> dates = parseCollection(baseDate, value);
     Assert.assertEquals(1, dates.size());
     return dates.get(0);
   }
@@ -66,6 +66,10 @@ public abstract class AbstractTest {
   protected void validateDate(Date baseDate, String value, int month, int day, int year) {
     Date date = parseSingleDate(value, baseDate);
     validateDate(date, month, day, year);
+  }
+
+  protected void validateDate(String value, int month, int day, int year) {
+    validateDate(new Date(), value, month, day, year);
   }
   
   /**

--- a/src/test/java/com/joestelmach/natty/AbstractTest.java
+++ b/src/test/java/com/joestelmach/natty/AbstractTest.java
@@ -37,8 +37,8 @@ public abstract class AbstractTest {
    * @param value
    * @return
    */
-  protected List<Date> parseCollection(Date baseDate, String value) {
-    List<DateGroup> dateGroup = _parser.parse(value, baseDate);
+  protected List<Date> parseCollection(Date referenceDate, String value) {
+    List<DateGroup> dateGroup = _parser.parse(value, referenceDate);
     return dateGroup.isEmpty() ? new ArrayList<Date>() : dateGroup.get(0).getDates();
   }
   
@@ -48,8 +48,8 @@ public abstract class AbstractTest {
    * @param value
    * @return
    */
-  protected Date parseSingleDate(String value, Date baseDate) {
-    List<Date> dates = parseCollection(baseDate, value);
+  protected Date parseSingleDate(String value, Date referenceDate) {
+    List<Date> dates = parseCollection(referenceDate, value);
     Assert.assertEquals(1, dates.size());
     return dates.get(0);
   }
@@ -63,8 +63,8 @@ public abstract class AbstractTest {
    * @param day
    * @param year
    */
-  protected void validateDate(Date baseDate, String value, int month, int day, int year) {
-    Date date = parseSingleDate(value, baseDate);
+  protected void validateDate(Date referenceDate, String value, int month, int day, int year) {
+    Date date = parseSingleDate(value, referenceDate);
     validateDate(date, month, day, year);
   }
 
@@ -97,8 +97,8 @@ public abstract class AbstractTest {
    * @param minutes
    * @param seconds
    */
-  protected void validateTime(Date baseDate, String value, int hours, int minutes, int seconds) {
-    Date date = parseSingleDate(value, baseDate);
+  protected void validateTime(Date referenceDate, String value, int hours, int minutes, int seconds) {
+    Date date = parseSingleDate(value, referenceDate);
     validateTime(date, hours, minutes, seconds);
   }
   
@@ -131,10 +131,10 @@ public abstract class AbstractTest {
    * @param minutes
    * @param seconds
    */
-  protected void validateDateTime(Date baseDate, String value, int month, int day, int year,
+  protected void validateDateTime(Date referenceDate, String value, int month, int day, int year,
       int hours, int minutes, int seconds) {
     
-    Date date = parseSingleDate(value, baseDate);
+    Date date = parseSingleDate(value, referenceDate);
     validateDateTime(date, month, day, year, hours, minutes, seconds);
   }
   

--- a/src/test/java/com/joestelmach/natty/DateTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTest.java
@@ -24,323 +24,323 @@ public class DateTest extends AbstractTest {
   
   @Test
   public void testFormal() {
-    validateDate("1978-01-28", 1, 28, 1978);
-    validateDate("2009-10-10", 10, 10, 2009);
-    validateDate("1980-1-2", 1, 2, 1980);
-    validateDate("12/12/12", 12, 12, 2012);
-    validateDate("3/4", 3, 4, Calendar.getInstance().get(Calendar.YEAR));
-    validateDate("sun, 11/21/2010", 11, 21, 2010);
-    validateDate("in october 2006", 10, 1, 2006);
-    validateDate("feb 1979", 2, 1, 1979);
-    validateDate("jan '80", 1, 1, 1980);
-    validateDate("2006-Jun-16", 6, 16, 2006);
-    validateDate("28-Feb-2010", 2, 28, 2010);
-    validateDate("9-Apr", 4, 9, Calendar.getInstance().get(Calendar.YEAR));
-    validateDate("jan 10, '00", 1, 10, 2000);
+    validateDate(new Date(), "1978-01-28", 1, 28, 1978);
+    validateDate(new Date(), "2009-10-10", 10, 10, 2009);
+    validateDate(new Date(), "1980-1-2", 1, 2, 1980);
+    validateDate(new Date(), "12/12/12", 12, 12, 2012);
+    validateDate(new Date(), "3/4", 3, 4, Calendar.getInstance().get(Calendar.YEAR));
+    validateDate(new Date(), "sun, 11/21/2010", 11, 21, 2010);
+    validateDate(new Date(), "in october 2006", 10, 1, 2006);
+    validateDate(new Date(), "feb 1979", 2, 1, 1979);
+    validateDate(new Date(), "jan '80", 1, 1, 1980);
+    validateDate(new Date(), "2006-Jun-16", 6, 16, 2006);
+    validateDate(new Date(), "28-Feb-2010", 2, 28, 2010);
+    validateDate(new Date(), "9-Apr", 4, 9, Calendar.getInstance().get(Calendar.YEAR));
+    validateDate(new Date(), "jan 10, '00", 1, 10, 2000);
   }
   
   @Test
   public void testRelaxed() {
-    validateDate("oct 1, 1980", 10, 1, 1980);
-    validateDate("oct. 1, 1980", 10, 1, 1980);
-    validateDate("oct 1,1980", 10, 1, 1980);
-    validateDate("1st oct in the year '89", 10, 1, 1989);
-    validateDate("thirty first of december '80", 12, 31, 1980);
-    validateDate("the first of december in the year 1980", 12, 1, 1980);
-    validateDate("the 2 of february in the year 1980", 2, 2, 1980);
-    validateDate("the 2nd of february in the year 1980", 2, 2, 1980);
-    validateDate("the second of february in the year 1980", 2, 2, 1980);
-    validateDate("jan. 2nd", 1, 2, Calendar.getInstance().get(Calendar.YEAR));
-    validateDate("sun, nov 21 2010", 11, 21, 2010);
-    validateDate("Second Monday in October 2017", 10, 9, 2017);
-    validateDate("2nd thursday in sept. '02", 9, 12, 2002);
+    validateDate(new Date(), "oct 1, 1980", 10, 1, 1980);
+    validateDate(new Date(), "oct. 1, 1980", 10, 1, 1980);
+    validateDate(new Date(), "oct 1,1980", 10, 1, 1980);
+    validateDate(new Date(), "1st oct in the year '89", 10, 1, 1989);
+    validateDate(new Date(), "thirty first of december '80", 12, 31, 1980);
+    validateDate(new Date(), "the first of december in the year 1980", 12, 1, 1980);
+    validateDate(new Date(), "the 2 of february in the year 1980", 2, 2, 1980);
+    validateDate(new Date(), "the 2nd of february in the year 1980", 2, 2, 1980);
+    validateDate(new Date(), "the second of february in the year 1980", 2, 2, 1980);
+    validateDate(new Date(), "jan. 2nd", 1, 2, Calendar.getInstance().get(Calendar.YEAR));
+    validateDate(new Date(), "sun, nov 21 2010", 11, 21, 2010);
+    validateDate(new Date(), "Second Monday in October 2017", 10, 9, 2017);
+    validateDate(new Date(), "2nd thursday in sept. '02", 9, 12, 2002);
   }
   
   @Test
   public void testExplicitRelative() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("2/28/2011");
-    CalendarSource.setBaseDate(reference);
-    
-    validateDate("final thursday in april", 4, 28, 2011);
-    validateDate("final thurs in sep", 9, 29, 2011);
-    validateDate("4th february ", 2, 4, 2011);
+    calendarSource = new CalendarSource(reference);
+
+    validateDate(reference, "final thursday in april", 4, 28, 2011);
+    validateDate(reference, "final thurs in sep", 9, 29, 2011);
+    validateDate(reference, "4th february ", 2, 4, 2011);
   }
   
   @Test
   public void testRelative() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("2/28/2011");
-    CalendarSource.setBaseDate(reference);
-    
-    validateDate("yesterday", 2, 27, 2011);
-    validateDate("tomorrow", 3, 1, 2011);
-    validateDate("tmr", 3, 1, 2011);
-    validateDate("in 3 days", 3, 3, 2011);
-    validateDate("3 days ago", 2, 25, 2011);
-    validateDate("in 3 weeks", 3, 21, 2011);
-    validateDate("four weeks ago", 1, 31, 2011);
-    validateDate("in 3 months", 5, 28, 2011);
-    validateDate("three months ago", 11, 28, 2010);
-    validateDate("in 3 years", 2, 28, 2014);
-    validateDate("seven years ago", 2, 28, 2004);
-    validateDate("60 years ago", 2, 28, 1951);
-    validateDate("32 days ago", 1, 27, 2011);
-    validateDate("320 days ago", 4, 14, 2010);
-    validateDate("1200 days ago", 11, 16, 2007);
-    validateDate("365 days from now", 2, 28, 2012);
-    validateDate("100 months now", 6, 28, 2019);
-    validateDate("100 years from now", 2, 28, 2111);
-    validateDate("next monday", 3, 7, 2011);
-    validateDate("next mon", 3, 7, 2011);
-    validateDate("4 mondays from now", 3, 28, 2011);
-    validateDate("4 mondays from today", 3, 28, 2011);
-    validateDate("next weekend", 3, 12, 2011);
-    validateDate("six mondays ago", 1, 17, 2011);
-    validateDate("last monday", 2, 21, 2011);
-    validateDate("last mon", 2, 21, 2011);
-    validateDate("this past mon", 2, 21, 2011);
-    validateDate("this coming mon", 3, 7, 2011);
-    validateDate("this upcoming mon", 3, 7, 2011);
-    validateDate("next thurs", 3, 10, 2011);
-    validateDate("next month", 3, 28, 2011);
-    validateDate("last month", 1, 28, 2011);
-    validateDate("next week", 3, 7, 2011);
-    validateDate("last week", 2, 21, 2011);
-    validateDate("next year", 2, 28, 2012);
-    validateDate("last year", 2, 28, 2010);
-    validateDate("tues this week", 3, 1, 2011);
-    validateDate("tuesday this week", 3, 1, 2011);
-    validateDate("tuesday next week", 3, 8, 2011);
-    validateDate("this september", 9, 1, 2011);
-    validateDate("in a september", 9, 1, 2011);
-    validateDate("in an october", 10, 1, 2011);
-    validateDate("september", 9, 1, 2011);
-    validateDate("last september", 9, 1, 2010);
-    validateDate("next september", 9, 1, 2011);
-    validateDate("january", 1, 1, 2011);
-    validateDate("last january", 1, 1, 2011);
-    validateDate("next january", 1, 1, 2012);
-    validateDate("next february", 2, 1, 2012);
-    validateDate("last february", 2, 1, 2010);
-    validateDate("february ", 2, 1, 2011);
-    validateDate("in a year", 2, 28, 2012);
-    validateDate("in a week", 3, 7, 2011);
-    validateDate("the saturday after next", 3, 19, 2011);
-    validateDate("the monday after next", 3, 14, 2011);
-    validateDate("the monday after next monday", 3, 14, 2011);
-    validateDate("the monday before May 25", 5, 23, 2011);
-    validateDate("the 2nd monday before May 25", 5, 16, 2011);
-    validateDate("3 mondays after May 25", 6, 13, 2011);
-    validateDate("tuesday before last", 2, 15, 2011);
-    validateDate("a week from now", 3, 7, 2011);
-    validateDate("a month from today", 3, 28, 2011);
-    validateDate("a week after this friday", 3, 11, 2011);
-    validateDate("a week from this friday", 3, 11, 2011);
-    validateDate("two weeks from this friday", 3, 18, 2011);
-    validateDate("the second week after this friday", 3, 18, 2011);
-    validateDate("It's gonna snow! How about skiing tomorrow", 3, 1, 2011);
-    validateDate("A week on tuesday", 3, 8, 2011);
-    validateDate("A month ago", 1, 28, 2011);
-    validateDate("A week ago", 2, 21, 2011);
-    validateDate("A year ago", 2, 28, 2010);
-    validateDate("this month", 2, 28, 2011);
-    validateDate("current month", 2, 28, 2011);
-    validateDate("current year", 2, 28, 2011);
-    validateDate("first monday in 1 month", 3, 7, 2011);
-    validateDate("first monday of month in 1 month", 3, 7, 2011);
-    validateDate("first monday of 1 month", 3, 7, 2011);
-    validateDate("first monday in 2 months", 4, 4, 2011);
-    validateDate("first monday of 2 months", 4, 4, 2011);
-    validateDate("first monday of month 2 months", 4, 4, 2011);
-    validateDate("first monday of month in 2 months", 4, 4, 2011);
-    validateDate("first monday in 3 months", 5, 2, 2011);
-    validateDate("first monday of 3 months", 5, 2, 2011);
-    validateDate("first monday of month in 3 months", 5, 2, 2011);
-    validateDate("1 year 9 months from now", 11, 28, 2012);
-    validateDate("1 year 9 months 1 day from now", 11, 29, 2012);
-    validateDate("2 years 4 months ago", 10, 28, 2008);
-    validateDate("2 years 4 months 5 days ago", 10, 23, 2008);
+    calendarSource = new CalendarSource(reference);
+
+    validateDate(reference, "yesterday", 2, 27, 2011);
+    validateDate(reference, "tomorrow", 3, 1, 2011);
+    validateDate(reference, "tmr", 3, 1, 2011);
+    validateDate(reference, "in 3 days", 3, 3, 2011);
+    validateDate(reference, "3 days ago", 2, 25, 2011);
+    validateDate(reference, "in 3 weeks", 3, 21, 2011);
+    validateDate(reference, "four weeks ago", 1, 31, 2011);
+    validateDate(reference, "in 3 months", 5, 28, 2011);
+    validateDate(reference, "three months ago", 11, 28, 2010);
+    validateDate(reference, "in 3 years", 2, 28, 2014);
+    validateDate(reference, "seven years ago", 2, 28, 2004);
+    validateDate(reference, "60 years ago", 2, 28, 1951);
+    validateDate(reference, "32 days ago", 1, 27, 2011);
+    validateDate(reference, "320 days ago", 4, 14, 2010);
+    validateDate(reference, "1200 days ago", 11, 16, 2007);
+    validateDate(reference, "365 days from now", 2, 28, 2012);
+    validateDate(reference, "100 months now", 6, 28, 2019);
+    validateDate(reference, "100 years from now", 2, 28, 2111);
+    validateDate(reference, "next monday", 3, 7, 2011);
+    validateDate(reference, "next mon", 3, 7, 2011);
+    validateDate(reference, "4 mondays from now", 3, 28, 2011);
+    validateDate(reference, "4 mondays from today", 3, 28, 2011);
+    validateDate(reference, "next weekend", 3, 12, 2011);
+    validateDate(reference, "six mondays ago", 1, 17, 2011);
+    validateDate(reference, "last monday", 2, 21, 2011);
+    validateDate(reference, "last mon", 2, 21, 2011);
+    validateDate(reference, "this past mon", 2, 21, 2011);
+    validateDate(reference, "this coming mon", 3, 7, 2011);
+    validateDate(reference, "this upcoming mon", 3, 7, 2011);
+    validateDate(reference, "next thurs", 3, 10, 2011);
+    validateDate(reference, "next month", 3, 28, 2011);
+    validateDate(reference, "last month", 1, 28, 2011);
+    validateDate(reference, "next week", 3, 7, 2011);
+    validateDate(reference, "last week", 2, 21, 2011);
+    validateDate(reference, "next year", 2, 28, 2012);
+    validateDate(reference, "last year", 2, 28, 2010);
+    validateDate(reference, "tues this week", 3, 1, 2011);
+    validateDate(reference, "tuesday this week", 3, 1, 2011);
+    validateDate(reference, "tuesday next week", 3, 8, 2011);
+    validateDate(reference, "this september", 9, 1, 2011);
+    validateDate(reference, "in a september", 9, 1, 2011);
+    validateDate(reference, "in an october", 10, 1, 2011);
+    validateDate(reference, "september", 9, 1, 2011);
+    validateDate(reference, "last september", 9, 1, 2010);
+    validateDate(reference, "next september", 9, 1, 2011);
+    validateDate(reference, "january", 1, 1, 2011);
+    validateDate(reference, "last january", 1, 1, 2011);
+    validateDate(reference, "next january", 1, 1, 2012);
+    validateDate(reference, "next february", 2, 1, 2012);
+    validateDate(reference, "last february", 2, 1, 2010);
+    validateDate(reference, "february ", 2, 1, 2011);
+    validateDate(reference, "in a year", 2, 28, 2012);
+    validateDate(reference, "in a week", 3, 7, 2011);
+    validateDate(reference, "the saturday after next", 3, 19, 2011);
+    validateDate(reference, "the monday after next", 3, 14, 2011);
+    validateDate(reference, "the monday after next monday", 3, 14, 2011);
+    validateDate(reference, "the monday before May 25", 5, 23, 2011);
+    validateDate(reference, "the 2nd monday before May 25", 5, 16, 2011);
+    validateDate(reference, "3 mondays after May 25", 6, 13, 2011);
+    validateDate(reference, "tuesday before last", 2, 15, 2011);
+    validateDate(reference, "a week from now", 3, 7, 2011);
+    validateDate(reference, "a month from today", 3, 28, 2011);
+    validateDate(reference, "a week after this friday", 3, 11, 2011);
+    validateDate(reference, "a week from this friday", 3, 11, 2011);
+    validateDate(reference, "two weeks from this friday", 3, 18, 2011);
+    validateDate(reference, "the second week after this friday", 3, 18, 2011);
+    validateDate(reference, "It's gonna snow! How about skiing tomorrow", 3, 1, 2011);
+    validateDate(reference, "A week on tuesday", 3, 8, 2011);
+    validateDate(reference, "A month ago", 1, 28, 2011);
+    validateDate(reference, "A week ago", 2, 21, 2011);
+    validateDate(reference, "A year ago", 2, 28, 2010);
+    validateDate(reference, "this month", 2, 28, 2011);
+    validateDate(reference, "current month", 2, 28, 2011);
+    validateDate(reference, "current year", 2, 28, 2011);
+    validateDate(reference, "first monday in 1 month", 3, 7, 2011);
+    validateDate(reference, "first monday of month in 1 month", 3, 7, 2011);
+    validateDate(reference, "first monday of 1 month", 3, 7, 2011);
+    validateDate(reference, "first monday in 2 months", 4, 4, 2011);
+    validateDate(reference, "first monday of 2 months", 4, 4, 2011);
+    validateDate(reference, "first monday of month 2 months", 4, 4, 2011);
+    validateDate(reference, "first monday of month in 2 months", 4, 4, 2011);
+    validateDate(reference, "first monday in 3 months", 5, 2, 2011);
+    validateDate(reference, "first monday of 3 months", 5, 2, 2011);
+    validateDate(reference, "first monday of month in 3 months", 5, 2, 2011);
+    validateDate(reference, "1 year 9 months from now", 11, 28, 2012);
+    validateDate(reference, "1 year 9 months 1 day from now", 11, 29, 2012);
+    validateDate(reference, "2 years 4 months ago", 10, 28, 2008);
+    validateDate(reference, "2 years 4 months 5 days ago", 10, 23, 2008);
   }
   
   @Test
   public void testRange() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("1/02/2011");
-    CalendarSource.setBaseDate(reference);
-    
-    List<Date> dates = parseCollection("monday to friday");
+    calendarSource = new CalendarSource(reference);
+
+    List<Date> dates = parseCollection("monday to friday", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 1, 7, 2011);
     
-    dates = parseCollection("1999-12-31 to tomorrow");
+    dates = parseCollection("1999-12-31 to tomorrow", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 12, 31, 1999);
     validateDate(dates.get(1), 1, 3, 2011);
     
-    dates = parseCollection("now to 2010-01-01");
+    dates = parseCollection("now to 2010-01-01", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 1, 1, 2010);
     
-    dates = parseCollection("jan 1 to 2");
+    dates = parseCollection("jan 1 to 2", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 1, 2011);
     validateDate(dates.get(1), 1, 2, 2011);
     
-    dates = parseCollection("may 2nd to 5th");
+    dates = parseCollection("may 2nd to 5th", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 5, 2, 2011);
     validateDate(dates.get(1), 5, 5, 2011);
     
-    dates = parseCollection("1/3 to 2/3");
+    dates = parseCollection("1/3 to 2/3", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 2, 3, 2011);
     
-    dates = parseCollection("2/3 to in one week");
+    dates = parseCollection("2/3 to in one week", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 2, 3, 2011);
     validateDate(dates.get(1), 1, 9, 2011);
     
-    dates = parseCollection("first day of may to last day of may");
+    dates = parseCollection("first day of may to last day of may", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 5, 1, 2011);
     validateDate(dates.get(1), 5, 31, 2011);
     
-    dates = parseCollection("feb 28th or 2 days after");
+    dates = parseCollection("feb 28th or 2 days after", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 2, 28, 2011);
     validateDate(dates.get(1), 3, 2, 2011);
     
-    dates = parseCollection("tomorrow at 10 and monday at 11");
+    dates = parseCollection("tomorrow at 10 and monday at 11", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 1, 3, 2011);
     
-    dates = parseCollection("tomorrow at 10 through tues at 11");
+    dates = parseCollection("tomorrow at 10 through tues at 11", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 1, 4, 2011);
     
-    dates = parseCollection("first day of 2009 to last day of 2009");
+    dates = parseCollection("first day of 2009 to last day of 2009", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 1, 2009);
     validateDate(dates.get(1), 12, 31, 2009);
     
-    dates = parseCollection("first to last day of 2008");
+    dates = parseCollection("first to last day of 2008", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 1, 2008);
     validateDate(dates.get(1), 12, 31, 2008);
     
-    dates = parseCollection("first to last day of september");
+    dates = parseCollection("first to last day of september", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 9, 1, 2011);
     validateDate(dates.get(1), 9, 30, 2011);
     
-    dates = parseCollection("first to last day of this september");
+    dates = parseCollection("first to last day of this september", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 9, 1, 2011);
     validateDate(dates.get(1), 9, 30, 2011);
     
-    dates = parseCollection("first to last day of 2 septembers ago");
+    dates = parseCollection("first to last day of 2 septembers ago", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 9, 1, 2009);
     validateDate(dates.get(1), 9, 30, 2009);
     
-    dates = parseCollection("first to last day of 2 septembers from now");
+    dates = parseCollection("first to last day of 2 septembers from now", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 9, 1, 2012);
     validateDate(dates.get(1), 9, 30, 2012);
     
-    dates = parseCollection("for 5 days");
+    dates = parseCollection("for 5 days", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 1, 7, 2011);
     
-    dates = parseCollection("for ten months");
+    dates = parseCollection("for ten months", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 11, 2, 2011);
     
-    dates = parseCollection("for twenty-five years");
+    dates = parseCollection("for twenty-five years", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 1, 2, 2036);
 
-    dates = parseCollection("2 and 4 months");
+    dates = parseCollection("2 and 4 months", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 3, 2, 2011);
     validateDate(dates.get(1), 5, 2, 2011);
 
-    dates = parseCollection("in 2 to 4 months");
+    dates = parseCollection("in 2 to 4 months", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 3, 2, 2011);
     validateDate(dates.get(1), 5, 2, 2011);
 
-    dates = parseCollection("for 2 to 4 months");
+    dates = parseCollection("for 2 to 4 months", reference);
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 3, 2, 2011);
     validateDate(dates.get(2), 5, 2, 2011);
 
-    dates = parseCollection("next 2 to 4 months");
+    dates = parseCollection("next 2 to 4 months", reference);
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 3, 2, 2011);
     validateDate(dates.get(2), 5, 2, 2011);
 
-    dates = parseCollection("2 to 4 months from now");
+    dates = parseCollection("2 to 4 months from now", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 3, 2, 2011);
     validateDate(dates.get(1), 5, 2, 2011);
 
-    dates = parseCollection("last 2 to 4 months");
+    dates = parseCollection("last 2 to 4 months", reference);
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 11, 2, 2010);
     validateDate(dates.get(2), 9, 2, 2010);
 
-    dates = parseCollection("past 2 to 4 months");
+    dates = parseCollection("past 2 to 4 months", reference);
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 11, 2, 2010);
     validateDate(dates.get(2), 9, 2, 2010);
 
-    dates = parseCollection("2 to 4 months ago");
+    dates = parseCollection("2 to 4 months ago", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 11, 2, 2010);
     validateDate(dates.get(1), 9, 2, 2010);
 
-    dates = parseCollection("2 or 3 days ago");
+    dates = parseCollection("2 or 3 days ago", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 12, 31, 2010);
     validateDate(dates.get(1), 12, 30, 2010);
 
-    dates = parseCollection("1 to 2 days");
+    dates = parseCollection("1 to 2 days", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 1, 4, 2011);
 
-    dates = parseCollection("I want to go shopping in Knoxville, TN in the next five to six months.");
+    dates = parseCollection("I want to go shopping in Knoxville, TN in the next five to six months.", reference);
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 6, 2, 2011);
     validateDate(dates.get(2), 7, 2, 2011);
 
-    dates = parseCollection("I want to watch the fireworks in the next two to three months.");
+    dates = parseCollection("I want to watch the fireworks in the next two to three months.", reference);
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 3, 2, 2011);
     validateDate(dates.get(2), 4, 2, 2011);
 
-    dates = parseCollection("september 7th something");
+    dates = parseCollection("september 7th something", reference);
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 9, 7, 2011);
     
-    dates = parseCollection("september 7th something happened here");
+    dates = parseCollection("september 7th something happened here", reference);
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 9, 7, 2011);
     
-    dates = parseCollection("bla bla bla 2 and 4 month");
+    dates = parseCollection("bla bla bla 2 and 4 month", reference);
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 3, 2, 2011);
     validateDate(dates.get(1), 5, 2, 2011);
@@ -356,10 +356,10 @@ public class DateTest extends AbstractTest {
     // Same time as
     // 2012, June 2, Saturday, 10 p.m. in US/Pacific GMT -7
     Calendar earlySunday = new GregorianCalendar(2012, 5, 3, 1, 0);
-    CalendarSource.setBaseDate(earlySunday.getTime());
+    calendarSource = new CalendarSource(earlySunday.getTime());
 
     // Run
-    Date result = parser.parse("Sunday at 10am").get(0).getDates().get(0);
+    Date result = parser.parse("Sunday at 10am", earlySunday.getTime()).get(0).getDates().get(0);
 
     // Validate
     // Result should be June 3, 2012

--- a/src/test/java/com/joestelmach/natty/DateTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTest.java
@@ -24,36 +24,36 @@ public class DateTest extends AbstractTest {
   
   @Test
   public void testFormal() {
-    validateDate(new Date(), "1978-01-28", 1, 28, 1978);
-    validateDate(new Date(), "2009-10-10", 10, 10, 2009);
-    validateDate(new Date(), "1980-1-2", 1, 2, 1980);
-    validateDate(new Date(), "12/12/12", 12, 12, 2012);
-    validateDate(new Date(), "3/4", 3, 4, Calendar.getInstance().get(Calendar.YEAR));
-    validateDate(new Date(), "sun, 11/21/2010", 11, 21, 2010);
-    validateDate(new Date(), "in october 2006", 10, 1, 2006);
-    validateDate(new Date(), "feb 1979", 2, 1, 1979);
-    validateDate(new Date(), "jan '80", 1, 1, 1980);
-    validateDate(new Date(), "2006-Jun-16", 6, 16, 2006);
-    validateDate(new Date(), "28-Feb-2010", 2, 28, 2010);
-    validateDate(new Date(), "9-Apr", 4, 9, Calendar.getInstance().get(Calendar.YEAR));
-    validateDate(new Date(), "jan 10, '00", 1, 10, 2000);
+    validateDate("1978-01-28", 1, 28, 1978);
+    validateDate("2009-10-10", 10, 10, 2009);
+    validateDate("1980-1-2", 1, 2, 1980);
+    validateDate("12/12/12", 12, 12, 2012);
+    validateDate("3/4", 3, 4, Calendar.getInstance().get(Calendar.YEAR));
+    validateDate("sun, 11/21/2010", 11, 21, 2010);
+    validateDate("in october 2006", 10, 1, 2006);
+    validateDate("feb 1979", 2, 1, 1979);
+    validateDate("jan '80", 1, 1, 1980);
+    validateDate("2006-Jun-16", 6, 16, 2006);
+    validateDate("28-Feb-2010", 2, 28, 2010);
+    validateDate("9-Apr", 4, 9, Calendar.getInstance().get(Calendar.YEAR));
+    validateDate("jan 10, '00", 1, 10, 2000);
   }
   
   @Test
   public void testRelaxed() {
-    validateDate(new Date(), "oct 1, 1980", 10, 1, 1980);
-    validateDate(new Date(), "oct. 1, 1980", 10, 1, 1980);
-    validateDate(new Date(), "oct 1,1980", 10, 1, 1980);
-    validateDate(new Date(), "1st oct in the year '89", 10, 1, 1989);
-    validateDate(new Date(), "thirty first of december '80", 12, 31, 1980);
-    validateDate(new Date(), "the first of december in the year 1980", 12, 1, 1980);
-    validateDate(new Date(), "the 2 of february in the year 1980", 2, 2, 1980);
-    validateDate(new Date(), "the 2nd of february in the year 1980", 2, 2, 1980);
-    validateDate(new Date(), "the second of february in the year 1980", 2, 2, 1980);
-    validateDate(new Date(), "jan. 2nd", 1, 2, Calendar.getInstance().get(Calendar.YEAR));
-    validateDate(new Date(), "sun, nov 21 2010", 11, 21, 2010);
-    validateDate(new Date(), "Second Monday in October 2017", 10, 9, 2017);
-    validateDate(new Date(), "2nd thursday in sept. '02", 9, 12, 2002);
+    validateDate("oct 1, 1980", 10, 1, 1980);
+    validateDate("oct. 1, 1980", 10, 1, 1980);
+    validateDate("oct 1,1980", 10, 1, 1980);
+    validateDate("1st oct in the year '89", 10, 1, 1989);
+    validateDate("thirty first of december '80", 12, 31, 1980);
+    validateDate("the first of december in the year 1980", 12, 1, 1980);
+    validateDate("the 2 of february in the year 1980", 2, 2, 1980);
+    validateDate("the 2nd of february in the year 1980", 2, 2, 1980);
+    validateDate("the second of february in the year 1980", 2, 2, 1980);
+    validateDate("jan. 2nd", 1, 2, Calendar.getInstance().get(Calendar.YEAR));
+    validateDate("sun, nov 21 2010", 11, 21, 2010);
+    validateDate("Second Monday in October 2017", 10, 9, 2017);
+    validateDate("2nd thursday in sept. '02", 9, 12, 2002);
   }
   
   @Test
@@ -166,181 +166,181 @@ public class DateTest extends AbstractTest {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("1/02/2011");
     calendarSource = new CalendarSource(reference);
 
-    List<Date> dates = parseCollection("monday to friday", reference);
+    List<Date> dates = parseCollection(reference, "monday to friday");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 1, 7, 2011);
     
-    dates = parseCollection("1999-12-31 to tomorrow", reference);
+    dates = parseCollection(reference, "1999-12-31 to tomorrow");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 12, 31, 1999);
     validateDate(dates.get(1), 1, 3, 2011);
     
-    dates = parseCollection("now to 2010-01-01", reference);
+    dates = parseCollection(reference, "now to 2010-01-01");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 1, 1, 2010);
     
-    dates = parseCollection("jan 1 to 2", reference);
+    dates = parseCollection(reference, "jan 1 to 2");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 1, 2011);
     validateDate(dates.get(1), 1, 2, 2011);
     
-    dates = parseCollection("may 2nd to 5th", reference);
+    dates = parseCollection(reference, "may 2nd to 5th");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 5, 2, 2011);
     validateDate(dates.get(1), 5, 5, 2011);
     
-    dates = parseCollection("1/3 to 2/3", reference);
+    dates = parseCollection(reference, "1/3 to 2/3");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 2, 3, 2011);
     
-    dates = parseCollection("2/3 to in one week", reference);
+    dates = parseCollection(reference, "2/3 to in one week");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 2, 3, 2011);
     validateDate(dates.get(1), 1, 9, 2011);
     
-    dates = parseCollection("first day of may to last day of may", reference);
+    dates = parseCollection(reference, "first day of may to last day of may");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 5, 1, 2011);
     validateDate(dates.get(1), 5, 31, 2011);
     
-    dates = parseCollection("feb 28th or 2 days after", reference);
+    dates = parseCollection(reference, "feb 28th or 2 days after");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 2, 28, 2011);
     validateDate(dates.get(1), 3, 2, 2011);
     
-    dates = parseCollection("tomorrow at 10 and monday at 11", reference);
+    dates = parseCollection(reference, "tomorrow at 10 and monday at 11");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 1, 3, 2011);
     
-    dates = parseCollection("tomorrow at 10 through tues at 11", reference);
+    dates = parseCollection(reference, "tomorrow at 10 through tues at 11");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 1, 4, 2011);
     
-    dates = parseCollection("first day of 2009 to last day of 2009", reference);
+    dates = parseCollection(reference, "first day of 2009 to last day of 2009");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 1, 2009);
     validateDate(dates.get(1), 12, 31, 2009);
     
-    dates = parseCollection("first to last day of 2008", reference);
+    dates = parseCollection(reference, "first to last day of 2008");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 1, 2008);
     validateDate(dates.get(1), 12, 31, 2008);
     
-    dates = parseCollection("first to last day of september", reference);
+    dates = parseCollection(reference, "first to last day of september");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 9, 1, 2011);
     validateDate(dates.get(1), 9, 30, 2011);
     
-    dates = parseCollection("first to last day of this september", reference);
+    dates = parseCollection(reference, "first to last day of this september");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 9, 1, 2011);
     validateDate(dates.get(1), 9, 30, 2011);
     
-    dates = parseCollection("first to last day of 2 septembers ago", reference);
+    dates = parseCollection(reference, "first to last day of 2 septembers ago");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 9, 1, 2009);
     validateDate(dates.get(1), 9, 30, 2009);
     
-    dates = parseCollection("first to last day of 2 septembers from now", reference);
+    dates = parseCollection(reference, "first to last day of 2 septembers from now");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 9, 1, 2012);
     validateDate(dates.get(1), 9, 30, 2012);
     
-    dates = parseCollection("for 5 days", reference);
+    dates = parseCollection(reference, "for 5 days");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 1, 7, 2011);
     
-    dates = parseCollection("for ten months", reference);
+    dates = parseCollection(reference, "for ten months");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 11, 2, 2011);
     
-    dates = parseCollection("for twenty-five years", reference);
+    dates = parseCollection(reference, "for twenty-five years");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 1, 2, 2036);
 
-    dates = parseCollection("2 and 4 months", reference);
+    dates = parseCollection(reference, "2 and 4 months");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 3, 2, 2011);
     validateDate(dates.get(1), 5, 2, 2011);
 
-    dates = parseCollection("in 2 to 4 months", reference);
+    dates = parseCollection(reference, "in 2 to 4 months");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 3, 2, 2011);
     validateDate(dates.get(1), 5, 2, 2011);
 
-    dates = parseCollection("for 2 to 4 months", reference);
+    dates = parseCollection(reference, "for 2 to 4 months");
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 3, 2, 2011);
     validateDate(dates.get(2), 5, 2, 2011);
 
-    dates = parseCollection("next 2 to 4 months", reference);
+    dates = parseCollection(reference, "next 2 to 4 months");
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 3, 2, 2011);
     validateDate(dates.get(2), 5, 2, 2011);
 
-    dates = parseCollection("2 to 4 months from now", reference);
+    dates = parseCollection(reference, "2 to 4 months from now");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 3, 2, 2011);
     validateDate(dates.get(1), 5, 2, 2011);
 
-    dates = parseCollection("last 2 to 4 months", reference);
+    dates = parseCollection(reference, "last 2 to 4 months");
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 11, 2, 2010);
     validateDate(dates.get(2), 9, 2, 2010);
 
-    dates = parseCollection("past 2 to 4 months", reference);
+    dates = parseCollection(reference, "past 2 to 4 months");
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 11, 2, 2010);
     validateDate(dates.get(2), 9, 2, 2010);
 
-    dates = parseCollection("2 to 4 months ago", reference);
+    dates = parseCollection(reference, "2 to 4 months ago");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 11, 2, 2010);
     validateDate(dates.get(1), 9, 2, 2010);
 
-    dates = parseCollection("2 or 3 days ago", reference);
+    dates = parseCollection(reference, "2 or 3 days ago");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 12, 31, 2010);
     validateDate(dates.get(1), 12, 30, 2010);
 
-    dates = parseCollection("1 to 2 days", reference);
+    dates = parseCollection(reference, "1 to 2 days");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 1, 3, 2011);
     validateDate(dates.get(1), 1, 4, 2011);
 
-    dates = parseCollection("I want to go shopping in Knoxville, TN in the next five to six months.", reference);
+    dates = parseCollection(reference, "I want to go shopping in Knoxville, TN in the next five to six months.");
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 6, 2, 2011);
     validateDate(dates.get(2), 7, 2, 2011);
 
-    dates = parseCollection("I want to watch the fireworks in the next two to three months.", reference);
+    dates = parseCollection(reference, "I want to watch the fireworks in the next two to three months.");
     Assert.assertEquals(3, dates.size());
     validateDate(dates.get(0), 1, 2, 2011);
     validateDate(dates.get(1), 3, 2, 2011);
     validateDate(dates.get(2), 4, 2, 2011);
 
-    dates = parseCollection("september 7th something", reference);
+    dates = parseCollection(reference, "september 7th something");
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 9, 7, 2011);
     
-    dates = parseCollection("september 7th something happened here", reference);
+    dates = parseCollection(reference, "september 7th something happened here");
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 9, 7, 2011);
     
-    dates = parseCollection("bla bla bla 2 and 4 month", reference);
+    dates = parseCollection(reference, "bla bla bla 2 and 4 month");
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 3, 2, 2011);
     validateDate(dates.get(1), 5, 2, 2011);

--- a/src/test/java/com/joestelmach/natty/DateTimeTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTimeTest.java
@@ -27,110 +27,104 @@ public class DateTimeTest extends AbstractTest {
   public void testSpecific() throws Exception {
     Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT,
         DateFormat.SHORT).parse("5/19/2012 12:00 am");
-    CalendarSource.setBaseDate(reference);
+    calendarSource = new CalendarSource(reference);
 
-    validateDateTime("1st oct in the year '89 1300 hours", 10, 1, 1989, 13, 0, 0);
-    validateDateTime("1st oct in the year '89 at 1300 hours", 10, 1, 1989, 13, 0, 0);
-    validateDateTime("1st oct in the year '89, 13:00", 10, 1, 1989, 13, 0, 0);
-    validateDateTime("1st oct in the year '89,13:00", 10, 1, 1989, 13, 0, 0);
-    validateDateTime("1st oct in the year '89, at 13:00", 10, 1, 1989, 13, 0, 0);
-    validateDateTime("3am on oct 1st 2010", 10, 1, 2010, 3, 0, 0);
-    validateDateTime("3am, october first 2010", 10, 1, 2010, 3, 0, 0);
-    validateDateTime("3am,october first 2010", 10, 1, 2010, 3, 0, 0);
-    validateDateTime("3am, on october first 2010", 10, 1, 2010, 3, 0, 0);
-    validateDateTime("3am october first 2010", 10, 1, 2010, 3, 0, 0);
-    validateDateTime("April 20, 10am", 4, 20, 2012, 10, 0, 0);
-    validateDateTime("April 20 10", 4, 20, 2012, 10, 0, 0);
-    validateDateTime("April 20 at 10 am", 4, 20, 2012, 10, 0, 0);
-    validateDateTime("Mar 16, 2015 3:33:39 PM", 3, 16, 2015, 15, 33, 39);
-    validateDateTime("15-Sep-2015 , 10:00 AM", 9, 15, 2015, 10, 00, 00);
+    validateDateTime(reference, "1st oct in the year '89 1300 hours", 10, 1, 1989, 13, 0, 0);
+    validateDateTime(reference, "1st oct in the year '89 at 1300 hours", 10, 1, 1989, 13, 0, 0);
+    validateDateTime(reference, "1st oct in the year '89, 13:00", 10, 1, 1989, 13, 0, 0);
+    validateDateTime(reference, "1st oct in the year '89,13:00", 10, 1, 1989, 13, 0, 0);
+    validateDateTime(reference, "1st oct in the year '89, at 13:00", 10, 1, 1989, 13, 0, 0);
+    validateDateTime(reference, "3am on oct 1st 2010", 10, 1, 2010, 3, 0, 0);
+    validateDateTime(reference, "3am, october first 2010", 10, 1, 2010, 3, 0, 0);
+    validateDateTime(reference, "3am,october first 2010", 10, 1, 2010, 3, 0, 0);
+    validateDateTime(reference, "3am, on october first 2010", 10, 1, 2010, 3, 0, 0);
+    validateDateTime(reference, "3am october first 2010", 10, 1, 2010, 3, 0, 0);
+    validateDateTime(reference, "April 20, 10am", 4, 20, 2012, 10, 0, 0);
+    validateDateTime(reference, "April 20 10", 4, 20, 2012, 10, 0, 0);
+    validateDateTime(reference, "April 20 at 10 am", 4, 20, 2012, 10, 0, 0);
+    validateDateTime(reference, "Mar 16, 2015 3:33:39 PM", 3, 16, 2015, 15, 33, 39);
   }
 
   @Test
   public void testRelative() throws Exception {
     Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT,
         DateFormat.SHORT).parse("2/24/2011 12:00 am");
-    CalendarSource.setBaseDate(reference);
+    calendarSource = new CalendarSource(reference);
 
-    validateDateTime("seven years ago at 3pm", 2, 24, 2004, 15, 0, 0);
-    validateDateTime("next wed. at 5pm", 3, 2, 2011, 17, 0, 0);
-    validateDateTime("3 days after next wed at 6a", 3, 5, 2011, 6, 0, 0);
-    validateDateTime("8pm on the sunday after next wed", 3, 6, 2011, 20, 0, 0);
-    validateDateTime("two days after today @ 6p", 2, 26, 2011, 18, 0, 0);
-    validateDateTime("two days from today @ 6p", 2, 26, 2011, 18, 0, 0);
-    validateDateTime("11:59 on 3 sundays after next wed", 3, 20, 2011, 11, 59, 0);
-    validateDateTime("the day after next 6pm", 2, 26, 2011, 18, 0, 0);
-    validateDateTime("the week after next 2a", 3, 10, 2011, 2, 0, 0);
-    validateDateTime("the month after next 0700", 4, 24, 2011, 7, 0, 0);
-    validateDateTime("the year after next @ midnight", 2, 24, 2013, 0, 0, 0);
-    validateDateTime("wed of the week after next in the evening", 3, 9, 2011, 19, 0, 0);
-    validateDateTime("the 28th of the month after next in the morning", 4, 28, 2011, 8, 0, 0);
-    validateDateTime("this morning", 2, 24, 2011, 8, 0, 0);
-    validateDateTime("this afternoon", 2, 24, 2011, 12, 0, 0);
-    validateDateTime("this evening", 2, 24, 2011, 19, 0, 0);
-    validateDateTime("today evening", 2, 24, 2011, 19, 0, 0);
-    validateDateTime("tomorrow evening", 2, 25, 2011, 19, 0, 0);
-    validateDateTime("friday evening", 2, 25, 2011, 19, 0, 0);
-    validateDateTime("monday 6 in the morning", 2, 28, 2011, 6, 0, 0);
-    validateDateTime("monday 4 in the afternoon", 2, 28, 2011, 16, 0, 0);
-    validateDateTime("monday 9 in the evening", 2, 28, 2011, 21, 0, 0);
-    validateDateTime("tomorrow @ noon", 2, 25, 2011, 12, 0, 0);
-    validateDateTime("Acknowledged. Let's meet at 9pm.", 2, 24, 2011, 21, 0, 0);
-    validateDateTime("tuesday,\u00A012:50 PM", 3, 1, 2011, 12, 50, 0);
-    validateDateTime("tonight at 6:30", 2, 24, 2011, 18, 30, 0);
-    validateDateTime("tonight at 6", 2, 24, 2011, 18, 0, 0);
-    validateDateTime("tonight at 2", 2, 25, 2011, 2, 0, 0);
-    validateDateTime("tonight at 4:59", 2, 25, 2011, 4, 59, 0);
-    validateDateTime("tonight at 5", 2, 24, 2011, 17, 0, 0);
-    validateDateTime("this evening at 5", 2, 24, 2011, 17, 0, 0);
-    validateDateTime("this evening at 2", 2, 25, 2011, 2, 0, 0);
-    validateDateTime("tomorrow evening at 5", 2, 25, 2011, 17, 0, 0);
-    validateDateTime("wed evening at 8:30", 3, 2, 2011, 20, 30, 0);
-    validateDateTime("750 minutes from now", 2, 24, 2011, 12, 30, 0);
-    validateDateTime("1500 minutes from now", 2, 25, 2011, 1, 0, 0);
-
-    // year boundary
-    reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("12/29/2015");
-    CalendarSource.setBaseDate(reference);
-    validateDateTime("Friday 2pm", 1, 1, 2016, 14, 0, 0);
+    validateDateTime(reference, "seven years ago at 3pm", 2, 24, 2004, 15, 0, 0);
+    validateDateTime(reference, "next wed. at 5pm", 3, 2, 2011, 17, 0, 0);
+    validateDateTime(reference, "3 days after next wed at 6a", 3, 5, 2011, 6, 0, 0);
+    validateDateTime(reference, "8pm on the sunday after next wed", 3, 6, 2011, 20, 0, 0);
+    validateDateTime(reference, "two days after today @ 6p", 2, 26, 2011, 18, 0, 0);
+    validateDateTime(reference, "two days from today @ 6p", 2, 26, 2011, 18, 0, 0);
+    validateDateTime(reference, "11:59 on 3 sundays after next wed", 3, 20, 2011, 11, 59, 0);
+    validateDateTime(reference, "the day after next 6pm", 2, 26, 2011, 18, 0, 0);
+    validateDateTime(reference, "the week after next 2a", 3, 10, 2011, 2, 0, 0);
+    validateDateTime(reference, "the month after next 0700", 4, 24, 2011, 7, 0, 0);
+    validateDateTime(reference, "the year after next @ midnight", 2, 24, 2013, 0, 0, 0);
+    validateDateTime(reference, "wed of the week after next in the evening", 3, 9, 2011, 19, 0, 0);
+    validateDateTime(reference, "the 28th of the month after next in the morning", 4, 28, 2011, 8, 0, 0);
+    validateDateTime(reference, "this morning", 2, 24, 2011, 8, 0, 0);
+    validateDateTime(reference, "this afternoon", 2, 24, 2011, 12, 0, 0);
+    validateDateTime(reference, "this evening", 2, 24, 2011, 19, 0, 0);
+    validateDateTime(reference, "today evening", 2, 24, 2011, 19, 0, 0);
+    validateDateTime(reference, "tomorrow evening", 2, 25, 2011, 19, 0, 0);
+    validateDateTime(reference, "friday evening", 2, 25, 2011, 19, 0, 0);
+    validateDateTime(reference, "monday 6 in the morning", 2, 28, 2011, 6, 0, 0);
+    validateDateTime(reference, "monday 4 in the afternoon", 2, 28, 2011, 16, 0, 0);
+    validateDateTime(reference, "monday 9 in the evening", 2, 28, 2011, 21, 0, 0);
+    validateDateTime(reference, "tomorrow @ noon", 2, 25, 2011, 12, 0, 0);
+    validateDateTime(reference, "Acknowledged. Let's meet at 9pm.", 2, 24, 2011, 21, 0, 0);
+    validateDateTime(reference, "tuesday,\u00A012:50 PM", 3, 1, 2011, 12, 50, 0);
+    validateDateTime(reference, "tonight at 6:30", 2, 24, 2011, 18, 30, 0);
+    validateDateTime(reference, "tonight at 6", 2, 24, 2011, 18, 0, 0);
+    validateDateTime(reference, "tonight at 2", 2, 25, 2011, 2, 0, 0);
+    validateDateTime(reference, "tonight at 4:59", 2, 25, 2011, 4, 59, 0);
+    validateDateTime(reference, "tonight at 5", 2, 24, 2011, 17, 0, 0);
+    validateDateTime(reference, "this evening at 5", 2, 24, 2011, 17, 0, 0);
+    validateDateTime(reference, "this evening at 2", 2, 25, 2011, 2, 0, 0);
+    validateDateTime(reference, "tomorrow evening at 5", 2, 25, 2011, 17, 0, 0);
+    validateDateTime(reference, "wed evening at 8:30", 3, 2, 2011, 20, 30, 0);
+    validateDateTime(reference, "750 minutes from now", 2, 24, 2011, 12, 30, 0);
+    validateDateTime(reference, "1500 minutes from now", 2, 25, 2011, 1, 0, 0);
   }
 
   @Test
   public void testRange() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("6/12/2010");
-    CalendarSource.setBaseDate(reference);
+    calendarSource = new CalendarSource(reference);
 
-    List<Date> dates = parseCollection("2009-03-10 9:00 to 11:00");
+    List<Date> dates = parseCollection("2009-03-10 9:00 to 11:00", reference);
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 3, 10, 2009, 9, 0, 0);
     validateDateTime(dates.get(1), 3, 10, 2009, 11, 0, 0);
 
-    dates = parseCollection("26 oct 10:00 am to 11:00 am");
+    dates = parseCollection("26 oct 10:00 am to 11:00 am", reference);
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 10, 26, 2010, 10, 0, 0);
     validateDateTime(dates.get(1), 10, 26, 2010, 11, 0, 0);
 
-    dates = parseCollection("16:00 nov 6 to 17:00");
+    dates = parseCollection("16:00 nov 6 to 17:00", reference);
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 11, 6, 2010, 16, 0, 0);
     validateDateTime(dates.get(1), 11, 6, 2010, 17, 0, 0);
 
-    dates = parseCollection("6am dec 5 to 7am");
+    dates = parseCollection("6am dec 5 to 7am", reference);
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 12, 5, 2010, 6, 0, 0);
     validateDateTime(dates.get(1), 12, 5, 2010, 7, 0, 0);
 
-    dates = parseCollection("3/3 21:00 to in 5 days");
+    dates = parseCollection("3/3 21:00 to in 5 days", reference);
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 3, 3, 2010, 21, 0, 0);
     validateDateTime(dates.get(1), 6, 17, 2010, 21, 0, 0);
 
-    dates = parseCollection("November 20 2 p.m. to 3 p.m");
+    dates = parseCollection("November 20 2 p.m. to 3 p.m", reference);
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 11, 20, 2010, 14, 0, 0);
     validateDateTime(dates.get(1), 11, 20, 2010, 15, 0, 0);
 
-    dates = parseCollection("November 20 2 p.m. - 3 p.m.");
+    dates = parseCollection("November 20 2 p.m. - 3 p.m.", reference);
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 11, 20, 2010, 14, 0, 0);
     validateDateTime(dates.get(1), 11, 20, 2010, 15, 0, 0);
@@ -139,34 +133,34 @@ public class DateTimeTest extends AbstractTest {
   @Test
   public void testList() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("05/19/2012");
-    CalendarSource.setBaseDate(reference);
+    calendarSource = new CalendarSource(reference);
 
     List<Date> dates =
-        parseCollection("June 25th at 9am and July 2nd at 10am and August 16th at 11am");
+        parseCollection("June 25th at 9am and July 2nd at 10am and August 16th at 11am", reference);
     Assert.assertEquals(3, dates.size());
     validateDateTime(dates.get(0), 6, 25, 2012, 9, 0, 0);
     validateDateTime(dates.get(1), 7, 2, 2012, 10, 0, 0);
     validateDateTime(dates.get(2), 8, 16, 2012, 11, 0, 0);
 
-    dates = parseCollection("June 25th at 10am and July 2nd and August 16th");
+    dates = parseCollection("June 25th at 10am and July 2nd and August 16th", reference);
     Assert.assertEquals(3, dates.size());
     validateDateTime(dates.get(0), 6, 25, 2012, 10, 0, 0);
     validateDateTime(dates.get(1), 7, 2, 2012, 10, 0, 0);
     validateDateTime(dates.get(2), 8, 16, 2012, 10, 0, 0);
 
-    dates = parseCollection("June 25th and July 2nd at 10am and August 16th");
+    dates = parseCollection("June 25th and July 2nd at 10am and August 16th", reference);
     Assert.assertEquals(3, dates.size());
     validateDateTime(dates.get(0), 6, 25, 2012, 10, 0, 0);
     validateDateTime(dates.get(1), 7, 2, 2012, 10, 0, 0);
     validateDateTime(dates.get(2), 8, 16, 2012, 10, 0, 0);
 
-    dates = parseCollection("June 25th and July 2nd and August 16th at 10am");
+    dates = parseCollection("June 25th and July 2nd and August 16th at 10am", reference);
     Assert.assertEquals(3, dates.size());
     validateDateTime(dates.get(0), 6, 25, 2012, 10, 0, 0);
     validateDateTime(dates.get(1), 7, 2, 2012, 10, 0, 0);
     validateDateTime(dates.get(2), 8, 16, 2012, 10, 0, 0);
 
-    dates = parseCollection("slept from 3:30 a.m. To 9:41 a.m. On April 10th");
+    dates = parseCollection("slept from 3:30 a.m. To 9:41 a.m. On April 10th", reference);
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 4, 10, 2012, 3, 30, 0);
     validateDateTime(dates.get(1), 4, 10, 2012, 9, 41, 0);

--- a/src/test/java/com/joestelmach/natty/DateTimeTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTimeTest.java
@@ -94,37 +94,37 @@ public class DateTimeTest extends AbstractTest {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("6/12/2010");
     calendarSource = new CalendarSource(reference);
 
-    List<Date> dates = parseCollection("2009-03-10 9:00 to 11:00", reference);
+    List<Date> dates = parseCollection(reference, "2009-03-10 9:00 to 11:00");
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 3, 10, 2009, 9, 0, 0);
     validateDateTime(dates.get(1), 3, 10, 2009, 11, 0, 0);
 
-    dates = parseCollection("26 oct 10:00 am to 11:00 am", reference);
+    dates = parseCollection(reference, "26 oct 10:00 am to 11:00 am");
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 10, 26, 2010, 10, 0, 0);
     validateDateTime(dates.get(1), 10, 26, 2010, 11, 0, 0);
 
-    dates = parseCollection("16:00 nov 6 to 17:00", reference);
+    dates = parseCollection(reference, "16:00 nov 6 to 17:00");
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 11, 6, 2010, 16, 0, 0);
     validateDateTime(dates.get(1), 11, 6, 2010, 17, 0, 0);
 
-    dates = parseCollection("6am dec 5 to 7am", reference);
+    dates = parseCollection(reference, "6am dec 5 to 7am");
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 12, 5, 2010, 6, 0, 0);
     validateDateTime(dates.get(1), 12, 5, 2010, 7, 0, 0);
 
-    dates = parseCollection("3/3 21:00 to in 5 days", reference);
+    dates = parseCollection(reference, "3/3 21:00 to in 5 days");
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 3, 3, 2010, 21, 0, 0);
     validateDateTime(dates.get(1), 6, 17, 2010, 21, 0, 0);
 
-    dates = parseCollection("November 20 2 p.m. to 3 p.m", reference);
+    dates = parseCollection(reference, "November 20 2 p.m. to 3 p.m");
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 11, 20, 2010, 14, 0, 0);
     validateDateTime(dates.get(1), 11, 20, 2010, 15, 0, 0);
 
-    dates = parseCollection("November 20 2 p.m. - 3 p.m.", reference);
+    dates = parseCollection(reference, "November 20 2 p.m. - 3 p.m.");
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 11, 20, 2010, 14, 0, 0);
     validateDateTime(dates.get(1), 11, 20, 2010, 15, 0, 0);
@@ -136,31 +136,31 @@ public class DateTimeTest extends AbstractTest {
     calendarSource = new CalendarSource(reference);
 
     List<Date> dates =
-        parseCollection("June 25th at 9am and July 2nd at 10am and August 16th at 11am", reference);
+        parseCollection(reference, "June 25th at 9am and July 2nd at 10am and August 16th at 11am");
     Assert.assertEquals(3, dates.size());
     validateDateTime(dates.get(0), 6, 25, 2012, 9, 0, 0);
     validateDateTime(dates.get(1), 7, 2, 2012, 10, 0, 0);
     validateDateTime(dates.get(2), 8, 16, 2012, 11, 0, 0);
 
-    dates = parseCollection("June 25th at 10am and July 2nd and August 16th", reference);
+    dates = parseCollection(reference, "June 25th at 10am and July 2nd and August 16th");
     Assert.assertEquals(3, dates.size());
     validateDateTime(dates.get(0), 6, 25, 2012, 10, 0, 0);
     validateDateTime(dates.get(1), 7, 2, 2012, 10, 0, 0);
     validateDateTime(dates.get(2), 8, 16, 2012, 10, 0, 0);
 
-    dates = parseCollection("June 25th and July 2nd at 10am and August 16th", reference);
+    dates = parseCollection(reference, "June 25th and July 2nd at 10am and August 16th");
     Assert.assertEquals(3, dates.size());
     validateDateTime(dates.get(0), 6, 25, 2012, 10, 0, 0);
     validateDateTime(dates.get(1), 7, 2, 2012, 10, 0, 0);
     validateDateTime(dates.get(2), 8, 16, 2012, 10, 0, 0);
 
-    dates = parseCollection("June 25th and July 2nd and August 16th at 10am", reference);
+    dates = parseCollection(reference, "June 25th and July 2nd and August 16th at 10am");
     Assert.assertEquals(3, dates.size());
     validateDateTime(dates.get(0), 6, 25, 2012, 10, 0, 0);
     validateDateTime(dates.get(1), 7, 2, 2012, 10, 0, 0);
     validateDateTime(dates.get(2), 8, 16, 2012, 10, 0, 0);
 
-    dates = parseCollection("slept from 3:30 a.m. To 9:41 a.m. On April 10th", reference);
+    dates = parseCollection(reference, "slept from 3:30 a.m. To 9:41 a.m. On April 10th");
     Assert.assertEquals(2, dates.size());
     validateDateTime(dates.get(0), 4, 10, 2012, 3, 30, 0);
     validateDateTime(dates.get(1), 4, 10, 2012, 9, 41, 0);

--- a/src/test/java/com/joestelmach/natty/IcsTest.java
+++ b/src/test/java/com/joestelmach/natty/IcsTest.java
@@ -21,133 +21,133 @@ public class IcsTest extends AbstractTest {
   @Test
   public void testUpcomingSeason() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("5/05/2011");
-    CalendarSource.setBaseDate(reference);
+    calendarSource = new CalendarSource(reference);
     
-    validateDate("spring", 3, 20, 2012);
-    validateDate("summer", 6, 21, 2011);
-    validateDate("fall", 9, 23, 2011);
-    validateDate("autumn", 9, 23, 2011);
-    validateDate("winter", 12, 22, 2011);
+    validateDate(reference, "spring", 3, 20, 2012);
+    validateDate(reference, "summer", 6, 21, 2011);
+    validateDate(reference, "fall", 9, 23, 2011);
+    validateDate(reference, "autumn", 9, 23, 2011);
+    validateDate(reference, "winter", 12, 22, 2011);
   }
   
   @Test
   public void testUpcomingHoliday() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("11/05/2011");
-    CalendarSource.setBaseDate(reference);
-    
-    validateDate("april fool's day", 4, 1, 2012);
-    validateDate("black friday", 11, 25, 2011);
-    validateDate("christmas", 12, 25, 2011);
-    validateDate("christmas eve", 12, 24, 2011);
-    validateDate("columbus day", 10, 8, 2012);
-    validateDate("earth day", 4, 22, 2012);
-    validateDate("easter", 4, 8, 2012);
-    validateDate("father's day", 6, 17, 2012);
-    validateDate("flag day", 6, 14, 2012);
-    validateDate("good friday", 4, 6, 2012);
-    validateDate("groundhog day", 2, 2, 2012);
-    validateDate("halloween", 10, 31, 2012);
-    validateDate("independence day", 7, 4, 2012);
-    validateDate("kwanzaa", 12, 26, 2011);
-    validateDate("labor day", 9, 3, 2012);
-    validateDate("mlk day", 1, 16, 2012);
-    validateDate("memorial day", 5, 28, 2012);
-    validateDate("mother's day", 5, 13, 2012);
-    validateDate("new year's day", 1, 1, 2012);
-    validateDate("new year's eve", 12, 31, 2011);
-    validateDate("patriot day", 9, 11, 2012);
-    validateDate("president's day", 2, 20, 2012);
-    validateDate("st patty's day", 3, 17, 2012);
-    validateDate("tax day", 4, 15, 2012);
-    validateDate("thanksgiving", 11, 24, 2011);
-    validateDate("election day", 11, 8, 2011);
-    validateDate("valentine day", 2, 14, 2012);
-    validateDate("veterans day", 11, 11, 2011);
+    calendarSource = new CalendarSource(reference);
+
+    validateDate(reference, "april fool's day", 4, 1, 2012);
+    validateDate(reference, "black friday", 11, 25, 2011);
+    validateDate(reference, "christmas", 12, 25, 2011);
+    validateDate(reference, "christmas eve", 12, 24, 2011);
+    validateDate(reference, "columbus day", 10, 8, 2012);
+    validateDate(reference, "earth day", 4, 22, 2012);
+    validateDate(reference, "easter", 4, 8, 2012);
+    validateDate(reference, "father's day", 6, 17, 2012);
+    validateDate(reference, "flag day", 6, 14, 2012);
+    validateDate(reference, "good friday", 4, 6, 2012);
+    validateDate(reference, "groundhog day", 2, 2, 2012);
+    validateDate(reference, "halloween", 10, 31, 2012);
+    validateDate(reference, "independence day", 7, 4, 2012);
+    validateDate(reference, "kwanzaa", 12, 26, 2011);
+    validateDate(reference, "labor day", 9, 3, 2012);
+    validateDate(reference, "mlk day", 1, 16, 2012);
+    validateDate(reference, "memorial day", 5, 28, 2012);
+    validateDate(reference, "mother's day", 5, 13, 2012);
+    validateDate(reference, "new year's day", 1, 1, 2012);
+    validateDate(reference, "new year's eve", 12, 31, 2011);
+    validateDate(reference, "patriot day", 9, 11, 2012);
+    validateDate(reference, "president's day", 2, 20, 2012);
+    validateDate(reference, "st patty's day", 3, 17, 2012);
+    validateDate(reference, "tax day", 4, 15, 2012);
+    validateDate(reference, "thanksgiving", 11, 24, 2011);
+    validateDate(reference, "election day", 11, 8, 2011);
+    validateDate(reference, "valentine day", 2, 14, 2012);
+    validateDate(reference, "veterans day", 11, 11, 2011);
   }
   
   @Test
   public void testRelativeHolidays() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("11/05/2011");
-    CalendarSource.setBaseDate(reference);
-    
-    validateDate("2 black fridays from now", 11, 23, 2012);
-    validateDate("three memorial days ago", 5, 25, 2009);
+    calendarSource = new CalendarSource(reference);
+
+    validateDate(reference, "2 black fridays from now", 11, 23, 2012);
+    validateDate(reference, "three memorial days ago", 5, 25, 2009);
   }
   
   @Test
   public void testSeasonsByYear() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("11/05/2011");
-    CalendarSource.setBaseDate(reference);
-    
-    validateDate("spring 2010", 3, 20, 2010);
-    validateDate("spring 2018", 3, 20, 2018);
-    validateDate("spring 1928", 3, 20, 1928);
+    calendarSource = new CalendarSource(reference);
 
-    validateDate("summer 2012", 6, 20, 2012);
-    validateDate("summer 2015", 6, 21, 2015);
-    validateDate("summer 1960", 6, 21, 1960);
+    validateDate(reference, "spring 2010", 3, 20, 2010);
+    validateDate(reference, "spring 2018", 3, 20, 2018);
+    validateDate(reference, "spring 1928", 3, 20, 1928);
 
-    validateDate("fall 2011", 9, 23, 2011);
-    validateDate("fall 2012", 9, 22, 2012);
-    validateDate("autumn 2016", 9, 22, 2016);
-    validateDate("autumn 1800", 9, 23, 1800);
+    validateDate(reference, "summer 2012", 6, 20, 2012);
+    validateDate(reference, "summer 2015", 6, 21, 2015);
+    validateDate(reference, "summer 1960", 6, 21, 1960);
 
-    validateDate("winter 2016", 12, 21, 2016);
-    validateDate("winter 2011", 12, 22, 2011);
-    validateDate("winter 1900", 12, 22, 1900);
+    validateDate(reference, "fall 2011", 9, 23, 2011);
+    validateDate(reference, "fall 2012", 9, 22, 2012);
+    validateDate(reference, "autumn 2016", 9, 22, 2016);
+    validateDate(reference, "autumn 1800", 9, 23, 1800);
+
+    validateDate(reference, "winter 2016", 12, 21, 2016);
+    validateDate(reference, "winter 2011", 12, 22, 2011);
+    validateDate(reference, "winter 1900", 12, 22, 1900);
   }
   
   @Test
   public void testHolidaysByYear() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("11/05/2011");
-    CalendarSource.setBaseDate(reference);
-    
-    validateDate("april fool's day 2000", 4, 1, 2000);
-    validateDate("black friday 2001", 11, 23, 2001);
-    validateDate("christmas 2002", 12, 25, 2002);
-    validateDate("christmas eve 2003", 12, 24, 2003);
-    validateDate("columbus day 2010", 10, 11, 2010);
-    validateDate("earth day 2005", 4, 22, 2005);
-    validateDate("easter '06", 4, 16, 2006);
-    validateDate("father's day '07", 6, 17, 2007);
-    validateDate("flag day '08", 6, 14, 2008);
-    validateDate("good friday '09", 4, 10, 2009);
-    validateDate("groundhog day '10", 2, 2, 2010);
-    validateDate("halloween '11", 10, 31, 2011);
-    validateDate("independence day '12", 7, 4, 2012);
-    validateDate("kwanzaa '13", 12, 26, 2013);
-    validateDate("labor day '14", 9, 1, 2014);
-    validateDate("mlk day '15", 1, 19, 2015);
-    validateDate("memorial day '16", 5, 30, 2016);
-    validateDate("mother's day 2017", 5, 14, 2017);
-    validateDate("new year's day 2018", 1, 1, 2018);
-    validateDate("new year's eve 2019", 12, 31, 2018);
-    validateDate("patriot day 2020", 9, 11, 2020);
-    validateDate("president's day 2019", 2, 18, 2019);
-    validateDate("st patty's day 2018", 3, 17, 2018);
-    validateDate("tax day 2017", 4, 15, 2017);
-    validateDate("thanksgiving 2016", 11, 24, 2016);
-    validateDate("election day 2015", 11, 3, 2015);
-    validateDate("valentine day 2014", 2, 14, 2014);
-    validateDate("veterans day 2013", 11, 11, 2013);
+    calendarSource = new CalendarSource(reference);
+
+    validateDate(reference, "april fool's day 2000", 4, 1, 2000);
+    validateDate(reference, "black friday 2001", 11, 23, 2001);
+    validateDate(reference, "christmas 2002", 12, 25, 2002);
+    validateDate(reference, "christmas eve 2003", 12, 24, 2003);
+    validateDate(reference, "columbus day 2010", 10, 11, 2010);
+    validateDate(reference, "earth day 2005", 4, 22, 2005);
+    validateDate(reference, "easter '06", 4, 16, 2006);
+    validateDate(reference, "father's day '07", 6, 17, 2007);
+    validateDate(reference, "flag day '08", 6, 14, 2008);
+    validateDate(reference, "good friday '09", 4, 10, 2009);
+    validateDate(reference, "groundhog day '10", 2, 2, 2010);
+    validateDate(reference, "halloween '11", 10, 31, 2011);
+    validateDate(reference, "independence day '12", 7, 4, 2012);
+    validateDate(reference, "kwanzaa '13", 12, 26, 2013);
+    validateDate(reference, "labor day '14", 9, 1, 2014);
+    validateDate(reference, "mlk day '15", 1, 19, 2015);
+    validateDate(reference, "memorial day '16", 5, 30, 2016);
+    validateDate(reference, "mother's day 2017", 5, 14, 2017);
+    validateDate(reference, "new year's day 2018", 1, 1, 2018);
+    validateDate(reference, "new year's eve 2019", 12, 31, 2018);
+    validateDate(reference, "patriot day 2020", 9, 11, 2020);
+    validateDate(reference, "president's day 2019", 2, 18, 2019);
+    validateDate(reference, "st patty's day 2018", 3, 17, 2018);
+    validateDate(reference, "tax day 2017", 4, 15, 2017);
+    validateDate(reference, "thanksgiving 2016", 11, 24, 2016);
+    validateDate(reference, "election day 2015", 11, 3, 2015);
+    validateDate(reference, "valentine day 2014", 2, 14, 2014);
+    validateDate(reference, "veterans day 2013", 11, 11, 2013);
   }
   
   @Test
   public void testHolidaysWithModifiers() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("11/05/2011");
-    CalendarSource.setBaseDate(reference);
-    
-    validateDate("four days before veterans day 2013", 11, 7, 2013);
-    validateDate("two days after two thanksgivings from now", 11, 24, 2012);
+    calendarSource = new CalendarSource(reference);
+
+    validateDate(reference, "four days before veterans day 2013", 11, 7, 2013);
+    validateDate(reference, "two days after two thanksgivings from now", 11, 24, 2012);
   }
   
   @Test
   public void testSeasonsWithModifiers() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("11/05/2011");
-    CalendarSource.setBaseDate(reference);
-    
-    validateDate("four days before fall 2013", 9, 18, 2013);
-    validateDate("two days after two summers from now", 6, 23, 2013);
-    validateDate("three summers ago", 6, 21, 2009);
+    calendarSource = new CalendarSource(reference);
+
+    validateDate(reference, "four days before fall 2013", 9, 18, 2013);
+    validateDate(reference, "two days after two summers from now", 6, 23, 2013);
+    validateDate(reference, "three summers ago", 6, 21, 2009);
   }
 }

--- a/src/test/java/com/joestelmach/natty/RecurrenceTest.java
+++ b/src/test/java/com/joestelmach/natty/RecurrenceTest.java
@@ -26,15 +26,15 @@ public class RecurrenceTest extends AbstractTest {
   public void testRelative() throws Exception {
     Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT, 
         DateFormat.SHORT).parse("3/3/2011 12:00 am");
-    CalendarSource.setBaseDate(reference);
+    calendarSource = new CalendarSource(reference);
     
-    DateGroup group = _parser.parse("every friday until two tuesdays from now").get(0);
+    DateGroup group = _parser.parse("every friday until two tuesdays from now", reference).get(0);
     Assert.assertEquals(1, group.getDates().size());
     validateDate(group.getDates().get(0), 3, 4, 2011);
     Assert.assertTrue(group.isRecurring());
     validateDate(group.getRecursUntil(), 3, 15, 2011);
     
-    group = _parser.parse("every saturday or sunday").get(0);
+    group = _parser.parse("every saturday or sunday", reference).get(0);
     Assert.assertEquals(2, group.getDates().size());
     validateDate(group.getDates().get(0), 3, 5, 2011);
     validateDate(group.getDates().get(1), 3, 6, 2011);

--- a/src/test/java/com/joestelmach/natty/SearchTest.java
+++ b/src/test/java/com/joestelmach/natty/SearchTest.java
@@ -25,10 +25,10 @@ public class SearchTest extends AbstractTest {
   @Test
   public void test() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("2/20/2011");
-    CalendarSource.setBaseDate(reference);
-    
+    calendarSource = new CalendarSource(reference);
+
     Parser parser = new Parser();
-    List<DateGroup> groups = parser.parse("golf tomorrow at 9 AM at pebble beach");
+    List<DateGroup> groups = parser.parse("golf tomorrow at 9 AM at pebble beach", reference);
     Assert.assertEquals(1, groups.size());
     DateGroup group = groups.get(0);
     Assert.assertEquals(1, group.getLine());
@@ -37,7 +37,7 @@ public class SearchTest extends AbstractTest {
     validateDate(group.getDates().get(0), 2, 21, 2011);
     validateTime(group.getDates().get(0), 9, 0, 0);
     
-    groups = parser.parse("golf with friends tomorrow at 10 ");
+    groups = parser.parse("golf with friends tomorrow at 10 ", reference);
     Assert.assertEquals(1, groups.size());
     group = groups.get(0);
     Assert.assertEquals(1, group.getLine());
@@ -47,7 +47,7 @@ public class SearchTest extends AbstractTest {
     validateTime(group.getDates().get(0), 10, 0, 0);
     
     parser = new Parser();
-    groups = parser.parse("golf with freinds tomorrow at 9 or Thursday at 10 am");
+    groups = parser.parse("golf with freinds tomorrow at 9 or Thursday at 10 am", reference);
     Assert.assertEquals(1, groups.size());
     List<Date> dates = groups.get(0).getDates();
     Assert.assertEquals(2, dates.size());
@@ -56,7 +56,7 @@ public class SearchTest extends AbstractTest {
     validateDate(dates.get(1), 2, 24, 2011); 
     validateTime(dates.get(1), 10, 0, 0); 
     
-    groups = parser.parse("golf with friends tomorrow at 9 or Thursday at 10");
+    groups = parser.parse("golf with friends tomorrow at 9 or Thursday at 10", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(2, dates.size());
@@ -65,162 +65,162 @@ public class SearchTest extends AbstractTest {
     validateDate(dates.get(1), 2, 24, 2011); 
     validateTime(dates.get(1), 10, 0, 0); 
     
-    groups = parser.parse("I want to go to park tomorrow and then email john@aol.com");
+    groups = parser.parse("I want to go to park tomorrow and then email john@aol.com", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 2, 21, 2011); 
     
-    groups = parser.parse("I want to pay off all my debt in the next two years.");
+    groups = parser.parse("I want to pay off all my debt in the next two years.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 2, 20, 2011); 
     validateDate(dates.get(1), 2, 20, 2013); 
     
-    groups = parser.parse("I want to purchase a car in the next month.");
+    groups = parser.parse("I want to purchase a car in the next month.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 3, 20, 2011); 
     
-    groups = parser.parse("I want to plan a get-together with my friends for this Friday.");
+    groups = parser.parse("I want to plan a get-together with my friends for this Friday.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 2, 25, 2011); 
     
-    groups = parser.parse("I want to lose five pounds in the next two months.");
+    groups = parser.parse("I want to lose five pounds in the next two months.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 2, 20, 2011); 
     validateDate(dates.get(1), 4, 20, 2011); 
     
-    groups = parser.parse("I want to finalize my college schedule by next week.");
+    groups = parser.parse("I want to finalize my college schedule by next week.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 2, 27, 2011); 
     
-    groups = parser.parse("I want to read this weekend.");
+    groups = parser.parse("I want to read this weekend.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 2, 26, 2011); 
     
-    groups = parser.parse("I want to travel a big chunk of world next year.");
+    groups = parser.parse("I want to travel a big chunk of world next year.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 2, 20, 2012); 
     
-    groups = parser.parse("last 2 weeks");
+    groups = parser.parse("last 2 weeks", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 2, 20, 2011); 
     validateDate(dates.get(1), 2, 6, 2011); 
     
-    groups = parser.parse("last 5 years");
+    groups = parser.parse("last 5 years", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 2, 20, 2011); 
     validateDate(dates.get(1), 2, 20, 2006); 
     
-    groups = parser.parse("next 5 years");
+    groups = parser.parse("next 5 years", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(2, dates.size());
     validateDate(dates.get(0), 2, 20, 2011); 
     validateDate(dates.get(1), 2, 20, 2016); 
     
-    groups = parser.parse("I want to go to my doctors appointment on May 15, 2011.");
+    groups = parser.parse("I want to go to my doctors appointment on May 15, 2011.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 5, 15, 2011); 
     
-    groups = parser.parse("I intend to become a zombie on December, 21st 2012.");
+    groups = parser.parse("I intend to become a zombie on December, 21st 2012.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 12, 21, 2012); 
     
-    groups = parser.parse("I want to hire a virtual assistant to do research for me on March 15, 2011");
+    groups = parser.parse("I want to hire a virtual assistant to do research for me on March 15, 2011", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 3, 15, 2011); 
     
-    groups = parser.parse("I want to see my mother on sunday.");
+    groups = parser.parse("I want to see my mother on sunday.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 2, 27, 2011); 
     
-    groups = parser.parse("I want to be able to jog 3 miles non-stop by September.");
+    groups = parser.parse("I want to be able to jog 3 miles non-stop by September.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 9, 1, 2011);
     
-    groups = parser.parse("I want to lose 10 lbs in 10 days");
+    groups = parser.parse("I want to lose 10 lbs in 10 days", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 3, 2, 2011); 
     
-    groups = parser.parse("I want to visit my grandfathers grave on December 30 2011");
+    groups = parser.parse("I want to visit my grandfathers grave on December 30 2011", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 12, 30, 2011); 
     
-    groups = parser.parse("i want to have 1 kid this year");
+    groups = parser.parse("i want to have 1 kid this year", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 2, 20, 2011); 
 
-    groups = parser.parse("save $1000 by September");
+    groups = parser.parse("save $1000 by September", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 9, 1, 2011);
 
-    groups = parser.parse("have my son play at muse music in provo UT at the 3 band cause they always have fog on the third band at 7:30");
+    groups = parser.parse("have my son play at muse music in provo UT at the 3 band cause they always have fog on the third band at 7:30", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDateTime(dates.get(0), 2, 20, 2011, 7, 30, 0); 
     
-    groups = parser.parse("i want to eat chinese tonight");
+    groups = parser.parse("i want to eat chinese tonight", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDateTime(dates.get(0), 2, 20, 2011, 20, 0, 0); 
     
-    groups = parser.parse("Watch School Spirits on June 20 on syfy channel");
+    groups = parser.parse("Watch School Spirits on June 20 on syfy channel", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 6, 20, 2011);
     
-    groups = parser.parse("Watch School Spirits on June 20 on");
+    groups = parser.parse("Watch School Spirits on June 20 on", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 6, 20, 2011);
     
-    groups = parser.parse("Watch School Spirits on June 20");
+    groups = parser.parse("Watch School Spirits on June 20", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 6, 20, 2011);
     
-    groups = parser.parse("hillary clinton sep 13, 2013");
+    groups = parser.parse("hillary clinton sep 13, 2013", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
@@ -228,7 +228,7 @@ public class SearchTest extends AbstractTest {
     Assert.assertEquals(17, groups.get(0).getPosition());
     Assert.assertEquals("sep 13, 2013", groups.get(0).getText());
     
-    groups = parser.parse("hillary clinton 9/13/2013");
+    groups = parser.parse("hillary clinton 9/13/2013", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
@@ -236,7 +236,7 @@ public class SearchTest extends AbstractTest {
     Assert.assertEquals(17, groups.get(0).getPosition());
     Assert.assertEquals("9/13/2013", groups.get(0).getText());
     
-    groups = parser.parse("hillary clintoo sep 13, 2013");
+    groups = parser.parse("hillary clintoo sep 13, 2013", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
@@ -244,7 +244,7 @@ public class SearchTest extends AbstractTest {
     Assert.assertEquals(17, groups.get(0).getPosition());
     Assert.assertEquals("sep 13, 2013", groups.get(0).getText());
     
-    groups = parser.parse("clinton sep 13 2013");
+    groups = parser.parse("clinton sep 13 2013", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
@@ -252,64 +252,64 @@ public class SearchTest extends AbstractTest {
     Assert.assertEquals(9, groups.get(0).getPosition());
     Assert.assertEquals("sep 13 2013", groups.get(0).getText());
     
-    groups = parser.parse("wedding dinner with Pam");
+    groups = parser.parse("wedding dinner with Pam", reference);
     Assert.assertEquals(0, groups.size());
     
-    groups = parser.parse("yummy fried chicken");
+    groups = parser.parse("yummy fried chicken", reference);
     Assert.assertEquals(0, groups.size());
     
-    groups = parser.parse("I am friend with Pam");
+    groups = parser.parse("I am friend with Pam", reference);
     Assert.assertEquals(0, groups.size());
     
-    groups = parser.parse("bfriday blah blah");
+    groups = parser.parse("bfriday blah blah", reference);
     Assert.assertEquals(0, groups.size());
     
-    groups = parser.parse("dinner bmong friends");
+    groups = parser.parse("dinner bmong friends", reference);
     Assert.assertEquals(0, groups.size());
 
-    groups = parser.parse("I know we should meet tomorrow");
+    groups = parser.parse("I know we should meet tomorrow", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 2, 21, 2011);
 
-    groups = parser.parse("**SHOT 01/31/15**");
+    groups = parser.parse("**SHOT 01/31/15**", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 1, 31, 2015);
 
-    groups = parser.parse("KOSTROMA REGION, RUSSIA. SEPTEMBER 24, 2014. A woman cleaning up fallen leaves on the grounds of the Shchelykovo museum reserve of Russian playwright Alexander Ostrovsky.");
+    groups = parser.parse("KOSTROMA REGION, RUSSIA. SEPTEMBER 24, 2014. A woman cleaning up fallen leaves on the grounds of the Shchelykovo museum reserve of Russian playwright Alexander Ostrovsky.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 9, 24, 2014);
 
-    groups = parser.parse("21 November 2014-NYC-USA **** STRICTLY NOT AVAILABLE FOR USA ***");
+    groups = parser.parse("21 November 2014-NYC-USA **** STRICTLY NOT AVAILABLE FOR USA ***", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 11, 21, 2014);
 
-    groups = parser.parse("...all the backstory I needed in the first two minutes. From there, I....");
+    groups = parser.parse("...all the backstory I needed in the first two minutes. From there, I....", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDateTime(dates.get(0), 2, 20, 2011, 0, 2, 0);
 
-    groups = parser.parse("earthquake occured 5km NNW of Vincent, California at 07:34 UTC! #earthquake #Vincent http://t.co/6e4fAC6hTU");
+    groups = parser.parse("earthquake occured 5km NNW of Vincent, California at 07:34 UTC! #earthquake #Vincent http://t.co/6e4fAC6hTU", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDateTime(dates.get(0), 2, 20, 2011, 2, 34, 0);
 
-    groups = parser.parse("Caricature: Person with anti-German foreign press. From: Le Rire, Paris, Spring 1933.");
+    groups = parser.parse("Caricature: Person with anti-German foreign press. From: Le Rire, Paris, Spring 1933.", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
     validateDate(dates.get(0), 3, 20, 1933);
 
-    groups = parser.parse("Person with Generaloberst von Seeckt in Bad Nauheim. Photograph. Autumn 1936");
+    groups = parser.parse("Person with Generaloberst von Seeckt in Bad Nauheim. Photograph. Autumn 1936", reference);
     Assert.assertEquals(1, groups.size());
     dates = groups.get(0).getDates();
     Assert.assertEquals(1, dates.size());
@@ -319,10 +319,10 @@ public class SearchTest extends AbstractTest {
   @Test
   public void testLocations() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("2/20/2011");
-    CalendarSource.setBaseDate(reference);
+    calendarSource = new CalendarSource(reference);
 
     Parser parser = new Parser();
-    List<DateGroup> groups = parser.parse("I want to go to the movies on september 1st.  Or maybe we should go on October 3rd.");
+    List<DateGroup> groups = parser.parse("I want to go to the movies on september 1st.  Or maybe we should go on October 3rd.", reference);
     Assert.assertEquals(2, groups.size());
     DateGroup group = groups.get(0);
     Assert.assertEquals(1, group.getLine());
@@ -331,7 +331,7 @@ public class SearchTest extends AbstractTest {
     Assert.assertEquals(1, group.getLine());
     Assert.assertEquals(72, group.getPosition());
 
-    groups = parser.parse("I want to go to \nthe movies on september 1st to see The Alan Turing Movie.");
+    groups = parser.parse("I want to go to \nthe movies on september 1st to see The Alan Turing Movie.", reference);
     Assert.assertEquals(1, groups.size());
     group = groups.get(0);
     Assert.assertEquals(2, group.getLine());
@@ -342,7 +342,7 @@ public class SearchTest extends AbstractTest {
   public void testPrefixSuffix() throws Exception {
 
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("2/20/2011");
-    CalendarSource.setBaseDate(reference);
+    calendarSource = new CalendarSource(reference);
 
     // no prefix or suffix
     Parser parser = new Parser();
@@ -402,10 +402,10 @@ public class SearchTest extends AbstractTest {
 
   @Test
   public void testNoDates() {
-    List<Date> dates = parseCollection("Fried Chicken, Wedding Dinner");
+    List<Date> dates = parseCollection("Fried Chicken, Wedding Dinner", new Date());
     Assert.assertEquals(0, dates.size());
 
-    parseCollection("Cleveland");
+    parseCollection("Cleveland", new Date());
     Assert.assertEquals(0, dates.size());
   }
 

--- a/src/test/java/com/joestelmach/natty/SearchTest.java
+++ b/src/test/java/com/joestelmach/natty/SearchTest.java
@@ -402,10 +402,10 @@ public class SearchTest extends AbstractTest {
 
   @Test
   public void testNoDates() {
-    List<Date> dates = parseCollection("Fried Chicken, Wedding Dinner", new Date());
+    List<Date> dates = parseCollection(new Date(), "Fried Chicken, Wedding Dinner");
     Assert.assertEquals(0, dates.size());
 
-    parseCollection("Cleveland", new Date());
+    parseCollection(new Date(), "Cleveland");
     Assert.assertEquals(0, dates.size());
   }
 

--- a/src/test/java/com/joestelmach/natty/ThreadSafetyTest.java
+++ b/src/test/java/com/joestelmach/natty/ThreadSafetyTest.java
@@ -54,13 +54,12 @@ public class ThreadSafetyTest extends AbstractTest {
     }
 
     public void run() {
-      CalendarSource.setBaseDate(baseDate);
       try {
         // Immitate some long running task.
         Thread.sleep(100);
       } catch (Exception e) { }
       String newDate = "4/4/2012";
-      Date parsed = _parser.parse(newDate).get(0).getDates().get(0);
+      Date parsed = _parser.parse(newDate, baseDate).get(0).getDates().get(0);
       validateThread(parsed, baseMinute);
       numOfCorrectResults.incrementAndGet();
     }

--- a/src/test/java/com/joestelmach/natty/ThreadSafetyTest.java
+++ b/src/test/java/com/joestelmach/natty/ThreadSafetyTest.java
@@ -44,12 +44,12 @@ public class ThreadSafetyTest extends AbstractTest {
 
   private class Tester implements Runnable {
 
-    private Date baseDate;
+    private Date referenceDate;
     private int baseMinute;
 
     public Tester(int baseMinute) throws Exception {
       String date = String.format("3/3/2011 1:%02d am", baseMinute);
-      this.baseDate = dateFormat.parse(date);
+      this.referenceDate = dateFormat.parse(date);
       this.baseMinute = baseMinute;
     }
 
@@ -59,7 +59,7 @@ public class ThreadSafetyTest extends AbstractTest {
         Thread.sleep(100);
       } catch (Exception e) { }
       String newDate = "4/4/2012";
-      Date parsed = _parser.parse(newDate, baseDate).get(0).getDates().get(0);
+      Date parsed = _parser.parse(newDate, referenceDate).get(0).getDates().get(0);
       validateThread(parsed, baseMinute);
       numOfCorrectResults.incrementAndGet();
     }

--- a/src/test/java/com/joestelmach/natty/TimeTest.java
+++ b/src/test/java/com/joestelmach/natty/TimeTest.java
@@ -30,85 +30,87 @@ public class TimeTest extends AbstractTest {
   @Test
   public void testFormal() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("1/02/2011");
-    CalendarSource.setBaseDate(reference);
-    validateTime("0600h", 6, 0, 0);
-    validateTime("06:00h", 6, 0, 0);
-    validateTime("06:00 hours", 6, 0, 0);
-    validateTime("0000", 0, 0, 0);
-    validateTime("0700h", 7, 0, 0);
-    validateTime("6pm", 18, 0, 0);
-    validateTime("5:30 a.m.", 5, 30, 0);
-    validateTime("5", 5, 0, 0);
-    validateTime("12:59", 12, 59, 0);
-    validateTime("23:59:28", 23, 59, 28);
-    validateTime("00:00", 0, 0, 0);
-    validateTime("10:00am", 10, 0, 0);
-    validateTime("10a", 10, 0, 0);
-    validateTime("10am", 10, 0, 0);
-    validateTime("10a_m", 10, 0, 0);
-    validateTime("10", 10, 0, 0);
-    validateTime("8p", 20, 0, 0);
-    validateTime("8pm", 20, 0, 0);
-    validateTime("8 pm", 20, 0, 0);
-    validateTime("8 p_m", 20, 0, 0);
+    calendarSource = new CalendarSource(reference);
+    validateTime(reference, "0600h", 6, 0, 0);
+    validateTime(reference, "06:00h", 6, 0, 0);
+    validateTime(reference, "06:00 hours", 6, 0, 0);
+    validateTime(reference, "0000", 0, 0, 0);
+    validateTime(reference, "0700h", 7, 0, 0);
+    validateTime(reference, "6pm", 18, 0, 0);
+    validateTime(reference, "5:30 a.m.", 5, 30, 0);
+    validateTime(reference, "5", 5, 0, 0);
+    validateTime(reference, "12:59", 12, 59, 0);
+    validateTime(reference, "23:59:28", 23, 59, 28);
+    validateTime(reference, "00:00", 0, 0, 0);
+    validateTime(reference, "10:00am", 10, 0, 0);
+    validateTime(reference, "10a", 10, 0, 0);
+    validateTime(reference, "10am", 10, 0, 0);
+    validateTime(reference, "10a_m", 10, 0, 0);
+    validateTime(reference, "10", 10, 0, 0);
+    validateTime(reference, "8p", 20, 0, 0);
+    validateTime(reference, "8pm", 20, 0, 0);
+    validateTime(reference, "8 pm", 20, 0, 0);
+    validateTime(reference, "8 p_m", 20, 0, 0);
   }
   
   @Test
   public void testRelaxed() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("1/02/2011");
-    CalendarSource.setBaseDate(reference);
-    validateTime("noon", 12, 0, 0);
-    validateTime("at noon", 12, 0, 0);
-    validateTime("afternoon", 12, 0, 0);
-    validateTime("midnight", 0, 0, 0);
-    validateTime("mid-night", 0, 0, 0);
-    validateTime("6 in the morning", 6, 0, 0);
-    validateTime("4 in the afternoon", 16, 0, 0);
-    validateTime("evening", 19, 0, 0);
-    validateTime("10 hours before noon", 2, 0, 0);
-    validateTime("10 hours before midnight", 14, 0, 0);
-    validateTime("5 hours after noon", 17, 0, 0);
-    validateTime("5 hours after midnight", 5, 0, 0);
-    validateTime("tonight", 20, 0, 0);
+    calendarSource = new CalendarSource(reference);
+    validateTime(reference, "noon", 12, 0, 0);
+    validateTime(reference, "at noon", 12, 0, 0);
+    validateTime(reference, "afternoon", 12, 0, 0);
+    validateTime(reference, "midnight", 0, 0, 0);
+    validateTime(reference, "mid-night", 0, 0, 0);
+    validateTime(reference, "6 in the morning", 6, 0, 0);
+    validateTime(reference, "4 in the afternoon", 16, 0, 0);
+    validateTime(reference, "evening", 19, 0, 0);
+    validateTime(reference, "10 hours before noon", 2, 0, 0);
+    validateTime(reference, "10 hours before midnight", 14, 0, 0);
+    validateTime(reference, "5 hours after noon", 17, 0, 0);
+    validateTime(reference, "5 hours after midnight", 5, 0, 0);
+    validateTime(reference, "tonight", 20, 0, 0);
   }
   
   @Test
   public void testRelative() throws Exception {
-    CalendarSource.setBaseDate(DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm"));
-    validateTime("in 5 seconds", 12, 0, 5);
-    validateTime("in 5 minutes", 12, 5, 0);
-    validateTime("in 5 hours", 17, 0, 0);
-    validateTime("4 seconds from now", 12, 0, 4);
-    validateTime("4 minutes from now", 12, 4, 0);
-    validateTime("4 hours from now", 16, 0, 0);
-    validateTime("next minute", 12, 1, 0);
-    validateTime("last minute", 11, 59, 0);
-    validateTime("next second", 12, 0, 1);
-    validateTime("this second", 12, 0, 0);
-    validateTime("this minute", 12, 0, 0);
-    validateTime("this hour", 12, 0, 0);
+    Date reference = DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm");
+    calendarSource = new CalendarSource(reference);
+    validateTime(reference, "in 5 seconds", 12, 0, 5);
+    validateTime(reference, "in 5 minutes", 12, 5, 0);
+    validateTime(reference, "in 5 hours", 17, 0, 0);
+    validateTime(reference, "4 seconds from now", 12, 0, 4);
+    validateTime(reference, "4 minutes from now", 12, 4, 0);
+    validateTime(reference, "4 hours from now", 16, 0, 0);
+    validateTime(reference, "next minute", 12, 1, 0);
+    validateTime(reference, "last minute", 11, 59, 0);
+    validateTime(reference, "next second", 12, 0, 1);
+    validateTime(reference, "this second", 12, 0, 0);
+    validateTime(reference, "this minute", 12, 0, 0);
+    validateTime(reference, "this hour", 12, 0, 0);
   }
 
   @Test
   public void testAlternatives() throws Exception {
-    CalendarSource.setBaseDate(DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm"));
+    Date reference = DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm");
+    calendarSource = new CalendarSource(reference);
 
-    List<Date> dates = parseCollection("12 or 12:30");
+    List<Date> dates = parseCollection("12 or 12:30", reference);
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 30, 0);
 
-    dates = parseCollection("12pm or 12:30");
+    dates = parseCollection("12pm or 12:30", reference);
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 30, 0);
 
-    dates = parseCollection("noon or 12:30");
+    dates = parseCollection("noon or 12:30", reference);
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 30, 0);
 
-    dates = parseCollection("12 or 12:30am");
+    dates = parseCollection("12 or 12:30am", reference);
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 0, 0, 0);
     validateTime(dates.get(1), 0, 30, 0);
@@ -116,19 +118,20 @@ public class TimeTest extends AbstractTest {
 
   @Test
   public void testRange() throws Exception {
-    CalendarSource.setBaseDate(DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm"));
-    
-    List<Date> dates = parseCollection("for six hours");
+    Date reference = DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm");
+    calendarSource = new CalendarSource(reference);
+
+    List<Date> dates = parseCollection("for six hours", reference);
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 18, 0, 0);
     
-    dates = parseCollection("for 12 minutes");
+    dates = parseCollection("for 12 minutes", reference);
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 12, 0);
     
-    dates = parseCollection("for 10 seconds");
+    dates = parseCollection("for 10 seconds", reference);
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 0, 10);
@@ -136,16 +139,16 @@ public class TimeTest extends AbstractTest {
 
   @Test
   public void testText() throws Exception {
-    CalendarSource.setBaseDate(DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm"));
+    Date reference = DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm");
 
-    List<DateGroup> groups = _parser.parse("5.30pm");
+    List<DateGroup> groups = _parser.parse("5.30pm", reference);
     Assert.assertEquals(1, groups.size());
     DateGroup group = groups.get(0);
     Assert.assertEquals(1, group.getDates().size());
     validateTime(group.getDates().get(0), 17, 30, 0);
     Assert.assertEquals("5.30pm", group.getText());
 
-    groups = _parser.parse("5:30pm");
+    groups = _parser.parse("5:30pm", reference);
     Assert.assertEquals(1, groups.size());
     group = groups.get(0);
     Assert.assertEquals(1, group.getDates().size());

--- a/src/test/java/com/joestelmach/natty/TimeTest.java
+++ b/src/test/java/com/joestelmach/natty/TimeTest.java
@@ -95,22 +95,22 @@ public class TimeTest extends AbstractTest {
     Date reference = DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm");
     calendarSource = new CalendarSource(reference);
 
-    List<Date> dates = parseCollection("12 or 12:30", reference);
+    List<Date> dates = parseCollection(reference, "12 or 12:30");
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 30, 0);
 
-    dates = parseCollection("12pm or 12:30", reference);
+    dates = parseCollection(reference, "12pm or 12:30");
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 30, 0);
 
-    dates = parseCollection("noon or 12:30", reference);
+    dates = parseCollection(reference, "noon or 12:30");
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 30, 0);
 
-    dates = parseCollection("12 or 12:30am", reference);
+    dates = parseCollection(reference, "12 or 12:30am");
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 0, 0, 0);
     validateTime(dates.get(1), 0, 30, 0);
@@ -121,17 +121,17 @@ public class TimeTest extends AbstractTest {
     Date reference = DateFormat.getTimeInstance(DateFormat.SHORT).parse("12:00 pm");
     calendarSource = new CalendarSource(reference);
 
-    List<Date> dates = parseCollection("for six hours", reference);
+    List<Date> dates = parseCollection(reference, "for six hours");
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 18, 0, 0);
     
-    dates = parseCollection("for 12 minutes", reference);
+    dates = parseCollection(reference, "for 12 minutes");
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 12, 0);
     
-    dates = parseCollection("for 10 seconds", reference);
+    dates = parseCollection(reference, "for 10 seconds");
     Assert.assertEquals(2, dates.size());
     validateTime(dates.get(0), 12, 0, 0);
     validateTime(dates.get(1), 12, 0, 10);

--- a/src/test/java/com/joestelmach/natty/TimeZoneTest.java
+++ b/src/test/java/com/joestelmach/natty/TimeZoneTest.java
@@ -21,21 +21,21 @@ public class TimeZoneTest extends AbstractTest {
   public void testSpecific() throws Exception {
     Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT,
         DateFormat.SHORT).parse("5/19/2012 12:00 am");
-    CalendarSource.setBaseDate(reference);
+    calendarSource = new CalendarSource(reference);
 
-    validateDateTime("2011-06-17T07:00:00Z", 6, 17, 2011, 3, 0, 0);
-    validateDateTime("05-Aug-2013 14:10:56 UTC", 8, 5, 2013, 10, 10, 56);
-    validateDateTime("5/1/13 01:00:00-8", 5, 1, 2013, 5, 0, 0);
-    validateDateTime("5/1/13 01:00:00 UTC", 4, 30, 2013, 21, 0, 0);
-    validateDateTime("5/1/13 01:00:00 UTC+8", 4, 30, 2013, 13, 0, 0);
-    validateDateTime("5/1/13 01:00:00 GMT-1", 4, 30, 2013, 22, 0, 0);
-    validateDateTime("tomorrow, 10 eastern time", 5, 20, 2012, 10, 0, 0);
-    validateDateTime("tomorrow, 10 central time", 5, 20, 2012, 11, 0, 0);
-    validateDateTime("tomorrow, 10 central", 5, 20, 2012, 11, 0, 0);
-    validateDateTime("tomorrow, 10 mountain time", 5, 20, 2012, 12, 0, 0);
-    validateDateTime("tomorrow, 10 pacific time", 5, 20, 2012, 13, 0, 0);
-    validateDateTime("tomorrow, 10pm pacific", 5, 21, 2012, 1, 0, 0);
-    validateDateTime("tomorrow, 10 alaska time", 5, 20, 2012, 14, 0, 0);
-    validateDateTime("tomorrow, 10 hawaii time", 5, 20, 2012, 16, 0, 0);
+    validateDateTime(reference, "2011-06-17T07:00:00Z", 6, 17, 2011, 3, 0, 0);
+    validateDateTime(reference, "05-Aug-2013 14:10:56 UTC", 8, 5, 2013, 10, 10, 56);
+    validateDateTime(reference, "5/1/13 01:00:00-8", 5, 1, 2013, 5, 0, 0);
+    validateDateTime(reference, "5/1/13 01:00:00 UTC", 4, 30, 2013, 21, 0, 0);
+    validateDateTime(reference, "5/1/13 01:00:00 UTC+8", 4, 30, 2013, 13, 0, 0);
+    validateDateTime(reference, "5/1/13 01:00:00 GMT-1", 4, 30, 2013, 22, 0, 0);
+    validateDateTime(reference, "tomorrow, 10 eastern time", 5, 20, 2012, 10, 0, 0);
+    validateDateTime(reference, "tomorrow, 10 central time", 5, 20, 2012, 11, 0, 0);
+    validateDateTime(reference, "tomorrow, 10 central", 5, 20, 2012, 11, 0, 0);
+    validateDateTime(reference, "tomorrow, 10 mountain time", 5, 20, 2012, 12, 0, 0);
+    validateDateTime(reference, "tomorrow, 10 pacific time", 5, 20, 2012, 13, 0, 0);
+    validateDateTime(reference, "tomorrow, 10pm pacific", 5, 21, 2012, 1, 0, 0);
+    validateDateTime(reference, "tomorrow, 10 alaska time", 5, 20, 2012, 14, 0, 0);
+    validateDateTime(reference, "tomorrow, 10 hawaii time", 5, 20, 2012, 16, 0, 0);
   }
 }


### PR DESCRIPTION
All existing functionality should remain the same, you can make a parse
of relative date phrases resolve with respect to a certain date with
`parser.parse(dateString, relativeDate);`