### PR TITLE
Make loggers in DateParser and DateLexer static to decrease overhead

### DIFF
--- a/src/main/antlr3/com/joestelmach/natty/generated/DateLexer.g
+++ b/src/main/antlr3/com/joestelmach/natty/generated/DateLexer.g
@@ -3,7 +3,7 @@ lexer grammar DateLexer;
 @header { package com.joestelmach.natty.generated; }
 
 @members {
-  private org.slf4j.Logger _logger =
+  private static org.slf4j.Logger _logger =
     org.slf4j.LoggerFactory.getLogger(com.joestelmach.natty.generated.DateLexer.class);
 
   @Override

--- a/src/main/antlr3/com/joestelmach/natty/generated/DateParser.g
+++ b/src/main/antlr3/com/joestelmach/natty/generated/DateParser.g
@@ -41,7 +41,7 @@ tokens {
 }
 
 @members {
-  private org.slf4j.Logger _logger =
+  private static org.slf4j.Logger _logger =
     org.slf4j.LoggerFactory.getLogger(com.joestelmach.natty.generated.DateParser.class);
 
   @Override


### PR DESCRIPTION
We did some profiling on an app we're using Natty for and logger creation takes a while because getLogger uses reflection (probably to detect logger name mismatch).

Making the loggers static should almost eliminate this overhead, and since most of the LoggerFactory implementations cache the loggers anyway, this shouldn't really change any behaviour.