### PR TITLE
Allow large numbers to be used in relative dates.

### DIFF
--- a/src/main/antlr3/com/joestelmach/natty/generated/imports/NumericRules.g
+++ b/src/main/antlr3/com/joestelmach/natty/generated/imports/NumericRules.g
@@ -60,12 +60,12 @@ spelled_or_int_01_to_31_optional_prefix
   | spelled_one_to_thirty_one
   ;
   
-// a number between 1 and 9999 either spelled-out, or as an
-// integer with an optional 0 prefix for numbers betwen 1 and 9
+// a number either spelled-out, or as an integer with an optional
+// 0 prefix for numbers betwen 1 and 9
 spelled_or_int_optional_prefix
   : spelled_one_to_thirty_one // TODO expand this spelled range to at least ninety-nine
   | ((int_01_to_31_optional_prefix | int_32_to_59 | int_60_to_99)
-     ( INT_0 | INT_00 | int_01_to_31_optional_prefix | int_32_to_59 | int_60_to_99)?
+     ( INT_0 | INT_00 | int_01_to_31_optional_prefix | int_32_to_59 | int_60_to_99)*
      
        -> INT[$spelled_or_int_optional_prefix.text])
   ;

--- a/src/test/java/com/joestelmach/natty/DateTimeTest.java
+++ b/src/test/java/com/joestelmach/natty/DateTimeTest.java
@@ -87,6 +87,14 @@ public class DateTimeTest extends AbstractTest {
     validateDateTime(reference, "wed evening at 8:30", 3, 2, 2011, 20, 30, 0);
     validateDateTime(reference, "750 minutes from now", 2, 24, 2011, 12, 30, 0);
     validateDateTime(reference, "1500 minutes from now", 2, 25, 2011, 1, 0, 0);
+    validateDateTime(reference, "50 seconds ago", 2, 23, 2011, 23, 59, 10);
+    validateDateTime(reference, "110 seconds ago", 2, 23, 2011, 23, 58, 10);
+    validateDateTime(reference, "6110 seconds ago", 2, 23, 2011, 22, 18, 10);
+    validateDateTime(reference, "86400 seconds ago", 2, 23, 2011, 0, 0, 0);
+    validateDateTime(reference, "86401 seconds ago", 2, 22, 2011, 23, 59, 59);
+    validateDateTime(reference, "86401 seconds ago", 2, 22, 2011, 23, 59, 59);
+    validateDateTime(reference, "2678400 seconds ago", 1, 24, 2011, 0, 0, 0);
+    validateDateTime(reference, "2678401 seconds ago", 1, 23, 2011, 23, 59, 59);
   }
 
   @Test


### PR DESCRIPTION
Before this change, "55010 seconds ago" is parsed as 010 seconds ago.  After, it is correctly recognised.